### PR TITLE
Update pipeline mutation

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -14,6 +14,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types:
+      - closed
+
 
 jobs:
   push_to_registries:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+    branches: [ "main" ]
 
 jobs:
   publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,23 @@ FROM python:3.11.9-alpine3.19
 COPY . /opt/kedro-graphql-viz
 
 ## required to build psutil
-RUN apk add gcc python3-dev musl-dev linux-headers \ 
-    && pip install -r /opt/kedro-graphql-viz/src/requirements.txt
+RUN apk add gcc python3-dev musl-dev linux-headers
+
+# Needed for pycurl (https://stackoverflow.com/a/50974082)
+RUN apk add --no-cache libcurl
+ENV PYCURL_SSL_LIBRARY=openssl
+
+# Install packages only needed for building, install and clean on a single layer
+RUN apk add --no-cache --virtual .build-dependencies build-base curl-dev \
+    && pip install pycurl \
+    && apk del .build-dependencies
+
+RUN pip install -r /opt/kedro-graphql-viz/src/requirements.txt
 
 WORKDIR /opt/kedro-graphql-viz
 
 RUN pip install -e .
+
+EXPOSE 5000
 
 CMD ["kedro", "gql", "--reload"]

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ and execute the following mutation:
 ```
 mutation MyMutation {
   pipeline(
-    pipeline: {name: "example00", parameters: [{name: "example", value: "hello"}, {name: "duration", value: "10"}], inputs: {name: "text_in", type: "text.TextDataSet", filepath: "./data/01_raw/text_in.txt"}, outputs: {name: "text_out", type: "text.TextDataSet", filepath: "./data/02_intermediate/text_out.txt"}}
+    pipeline: {name: "example00", parameters: [{name: "example", value: "hello"}, {name: "duration", value: "10"}], dataCatalog:[{name: "text_in",config: "{\"type\": \"text.TextDataset\",\"filepath\": \"./data/01_raw/text_in.txt\"}"},{name: "text_out",config: "{\"type\": \"text.TextDataset\",\"filepath\": \"./data/02_intermediate/text_out.txt\"}"}]}
   ) {
     id
     name

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -162,6 +162,17 @@ class Mutation:
         #p.kedro_catalog = info.context["request"].app.kedro_catalog
         #p.kedro_parameters = info.context["request"].app.kedro_parameters
         return p
+    
+    @strawberry.mutation(description = "Update a pipeline.")
+    def updatePipeline(self, id: str, pipeline: PipelineInput, info: Info) -> Pipeline:
+
+        pipeline_input_dict = jsonable_encoder(pipeline)
+        # Only update the keys in PipelineInput that have been supplied
+        # The key "name" is immutable and should never been updated
+        p = info.context["request"].app.backend.update(id=id, values={k: v for k, v in pipeline_input_dict.items() if k != "name" and v is not None})
+
+        return  p
+
 
 
 @strawberry.type


### PR DESCRIPTION
- Updated README.md mutation example to use `dataCatalog` PipelineInput field instead of the deprecated `inputs` and `outputs` fields
- Added dependencies for pycurl in Dockerfile to fix publish.yml workflow (https://stackoverflow.com/a/50974082)
- Added `updatePipeline` mutation to schema to override `dataCatalog`, `parameters`, or `tags` PipelineInput fields.