### PR TITLE
added 'created_at' field to Pipeline type

### DIFF
--- a/src/kedro_graphql/backends/base.py
+++ b/src/kedro_graphql/backends/base.py
@@ -20,7 +20,7 @@ class BaseBackend(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def list(self, cursor: uuid.UUID = None, limit: int = None, filter: str = None):
+    def list(self, cursor: uuid.UUID = None, limit: int = None, filter: str = None, sort: str = None):
         """List pipelines using cursor pagination"""
         raise NotImplementedError
 

--- a/src/kedro_graphql/models.py
+++ b/src/kedro_graphql/models.py
@@ -5,6 +5,7 @@ import uuid
 import json
 from .config import config as CONFIG
 from bson.objectid import ObjectId
+from datetime import datetime
 
 def mark_deprecated(default = None):
     return strawberry.field(default = default, deprecation_reason="see " + str(CONFIG["KEDRO_GRAPHQL_DEPRECATIONS_DOCS"]))
@@ -468,6 +469,7 @@ class Pipeline:
     task_traceback: Optional[str] = None
     task_einfo: Optional[str] = None
     task_result: Optional[str] = None
+    created_at: Optional[datetime] = None
 
     @strawberry.field
     def template(self) -> PipelineTemplate:
@@ -558,6 +560,7 @@ class Pipeline:
             task_exception = payload.get("task_exception", None),
             task_traceback = payload.get("task_traceback", None),
             task_einfo = payload.get("task_einfo", None),
+            created_at = datetime.fromisoformat(payload["created_at"]) if payload.get("created_at", None) else None
         )
 
 @strawberry.type

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -10,6 +10,7 @@ from .logs.logger import logger, PipelineLogStream
 from fastapi.encoders import jsonable_encoder
 from base64 import b64encode, b64decode
 from bson.objectid import ObjectId
+from datetime import datetime
 
 
 def encode_cursor(id: int) -> str:
@@ -112,6 +113,7 @@ class Mutation:
         d = jsonable_encoder(pipeline)
         p = Pipeline.from_dict(d)
         p.task_name = str(run_pipeline)
+        p.created_at = datetime.now()
 
         serial = p.serialize()
         ## credentials not supported yet

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -81,14 +81,14 @@ class Query:
         return p
 
     @strawberry.field(description = "Get a list of pipeline instances.")
-    def pipelines(self, info: Info, limit: int, cursor: Optional[str] = None, filter: Optional[str] = "") -> Pipelines:
+    def pipelines(self, info: Info, limit: int, cursor: Optional[str] = None, filter: Optional[str] = "", sort: Optional[str] = "") -> Pipelines:
         if cursor is not None:
             # decode the user ID from the given cursor.
             pipe_id = decode_cursor(cursor=cursor)
         else:
             pipe_id = "000000000000000000000000" ## unix epoch Jan 1, 1970 as objectId
 
-        results = info.context["request"].app.backend.list(cursor = pipe_id, limit = limit + 1, filter = filter)
+        results = info.context["request"].app.backend.list(cursor = pipe_id, limit = limit + 1, filter = filter, sort = sort)
 
         if len(results) > limit:
             # calculate the client's next cursor.


### PR DESCRIPTION
- Added a new `createdAt` field to the `Pipeline` GraphQL type to automatically capture the timestamp when the pipeline is created. The field will be resolved automatically when the pipeline object is instantiated and will not need to be supplied by the client. The `createdAt` field will return the creation timestamp in ISO 8601 format.
- Added a "sort" argument so users could sort multiple mongodb document fields lexicographically (ascending/descending)