### PR TITLE
feat: python client

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ After this, if you'd like to update your project requirements, please update `sr
 
 Added
 
-- a python client with CRUD support to facilitate integration with other python applications 
+- a python client with CRUD and subscription support to facilitate integration with other python applications 
   ```
   import json
   from kedro_graphql.models import Pipeline, PipelineInput, TagInput
@@ -653,6 +653,14 @@ Added
 
   ## create a pipeline
   pipeline = await client.create_pipeline(pipeline_input)
+
+  ## subscribe to pipeline events
+  async for event in client.pipeline_events(id=pipeline.id):
+      print(event.timestamp, event.status)
+
+  ## subscribe to pipeline logs
+  async for log in client.pipeline_logs(id=pipeline.id):
+      print(log.time, log.message)
 
   ## read a pipeline
   pipeline = await client.read_pipeline(id=pipeline.id)

--- a/README.md
+++ b/README.md
@@ -674,6 +674,9 @@ Added
 
   ## delete a pipeline
   pipeline = await client.delete_pipeline(id=pipeline.id)
+
+  ## close all sessions
+  await client.close_sessions()
   ```
 - [gql](https://gql.readthedocs.io/en/stable/) dependency in requirements.txt for the client
 - a `def delete_pipeline_collection` pytest fixture that will drop the "pipelines" collection after all tests have finished

--- a/src/kedro_graphql/celeryapp.py
+++ b/src/kedro_graphql/celeryapp.py
@@ -1,8 +1,9 @@
-import celery
+from celery import Celery
+from celery import signals
 
 
 def celery_app(config, backend):
-    app = celery.Celery()
+    app = Celery()
 
     class Config:
         broker_url = config["KEDRO_GRAPHQL_BROKER"]
@@ -21,7 +22,7 @@ def celery_app(config, backend):
     return app
 
 
-@celery.signals.setup_logging.connect
+@signals.setup_logging.connect
 def on_setup_logging(**kwargs):
     #  Disable Celery logging configuration so logs are captured in info.log and error.log
     # https://docs.celeryq.dev/en/latest/userguide/tasks.html#logging

--- a/src/kedro_graphql/client.py
+++ b/src/kedro_graphql/client.py
@@ -1,0 +1,344 @@
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+from gql.transport.websockets import WebsocketsTransport
+from kedro_graphql.models import PipelineInput, Pipeline, Pipelines, PipelineEvent, PipelineLogMessage
+from kedro_graphql.config import config
+
+
+PIPELINE_GQL = """{
+                    id
+                    parent
+                    name
+                    describe
+                    dataCatalog {
+                      name
+                      config
+                      tags {
+                        key
+                        value
+                      }
+                    }
+                    nodes {
+                      name
+                      inputs
+                      outputs
+                      tags
+                    }
+                    parameters {
+                      name
+                      value
+                      type
+                    }
+                    status {
+                      session
+                      state
+                      runner
+                      startedAt
+                      finishedAt
+                      taskId
+                      taskName
+                      taskArgs
+                      taskKwargs
+                      taskRequest
+                      taskException
+                      taskTraceback
+                      taskEinfo
+                      taskResult
+                    }
+                    tags {
+                      key
+                      value
+                    }
+                  }"""
+
+
+class KedroGraphqlClient():
+
+    def __init__(self, uri=None, ws=None):
+        """
+        Kwargs:
+            uri (str): uri to api [default: http://localhost:5000/graphql]
+
+        """
+        self.url = uri or config["KEDRO_GRAPHQL_UI_API_ENDPOINT"]
+        self.ws = ws or config["KEDRO_GRAPHQL_UI_WS_ENDPOINT"]
+        self._aio_transport = AIOHTTPTransport(url=self.url)
+        self._web_transport = WebsocketsTransport(url=self.ws)
+        self._aio_client = Client(transport=self._aio_transport)
+        self._aio_session = None
+        self._web_client = Client(transport=self._web_transport)
+        self._web_session = None
+
+    async def create_pipeline(self, pipeline_input: PipelineInput = None):
+        """Create a pipeline
+
+        Kwargs:
+            pipeline (PipelineInput): pipeline input object
+
+        Returns:
+            Pipeline: pipeline object
+        """
+        async with Client(
+            transport=self._aio_transport,
+        ) as gql_session:
+
+            query = gql(
+                """
+                mutation createPipeline($pipeline: PipelineInput!) {
+                  createPipeline(pipeline: $pipeline) """ + PIPELINE_GQL + """
+                }
+            """
+            )
+
+            result = await gql_session.execute(query, variable_values={"pipeline": pipeline_input.encode(encoder="graphql")})
+            return Pipeline.decode(result["createPipeline"], decoder="graphql")
+
+    async def read_pipeline(self, id: str = None):
+        """Read a pipeline.
+        Kwargs:
+            id (str): pipeline id
+
+        Returns:
+            Pipeline: pipeline object
+        """
+        async with Client(
+            transport=self._aio_transport,
+        ) as gql_session:
+
+            query = gql(
+                """
+                query readPipeline($id: String!) {
+                  readPipeline(id: $id) """ + PIPELINE_GQL + """
+                }
+            """
+            )
+            result = await gql_session.execute(query, variable_values={"id": str(id)})
+            return Pipeline.decode(result["readPipeline"], decoder="graphql")
+
+    async def read_pipelines(self, limit: int = 10, cursor: str = None, filter: str = None):
+        """Read pipelines.
+
+        Kwargs:
+            limit (int): limit
+            cursor (str): cursor
+            filter (str): a valid MongoDb document query filter https://www.mongodb.com/docs/manual/core/document/#std-label-document-query-filter.
+
+        Returns:
+            Pipelines (list): an list of pipeline objects
+        """
+
+        async with Client(
+            transport=self._aio_transport,
+        ) as gql_session:
+
+            query = gql(
+                """
+                query readPipelines($limit: Int!, $cursor: String, $filter: String!) {
+                  readPipelines(limit: $limit, cursor: $cursor, filter: $filter) { 
+                    pageMeta {
+                      nextCursor
+                    }
+                    pipelines """ + PIPELINE_GQL + """
+                  }
+                }
+            """
+            )
+            result = await gql_session.execute(query, variable_values={"limit": limit, "cursor": cursor, "filter": filter})
+            return Pipelines.decode(result, decoder="graphql")
+
+    async def update_pipeline(self, id: str = None, pipeline_input: PipelineInput = None):
+        """Update a pipeline
+
+        Kwargs:
+            id (str): pipeline id
+            pipeline_input (PipelineInput): pipeline input object
+
+        Returns:
+            Pipeline: pipeline object
+        """
+        async with Client(
+            transport=self._aio_transport,
+        ) as gql_session:
+
+            query = gql(
+                """
+                mutation updatePipeline($id: String!, $pipeline: PipelineInput!) {
+                  updatePipeline(id: $id, pipeline: $pipeline) {
+                    id
+                    name
+                    describe
+                    dataCatalog {
+                      name
+                      config
+                      tags {
+                        key
+                        value
+                      }
+                    }
+                    nodes {
+                      name
+                      inputs
+                      outputs
+                      tags
+                    }
+                    parameters {
+                      name
+                      value
+                      type
+                    }
+                    status {
+                      session
+                      state
+                      runner
+                      startedAt
+                      finishedAt
+                      taskId
+                      taskName
+                      taskArgs
+                      taskKwargs
+                      taskRequest
+                      taskException
+                      taskTraceback
+                      taskEinfo
+                      taskResult
+                    }
+                    tags {
+                      key
+                      value
+                    }
+                  }
+                }
+            """
+            )
+
+            result = await gql_session.execute(query, variable_values={"id": str(id), "pipeline": pipeline_input.encode(encoder="graphql")})
+            return Pipeline.decode(result["updatePipeline"], decoder="graphql")
+
+    async def delete_pipeline(self, id: str = None):
+        """Delete a pipeline.
+
+        Kwargs:
+            id (str): pipeline id
+
+        Returns:
+            Pipeline: pipeline object that was deleted.
+        """
+        async with Client(
+            transport=self._aio_transport,
+        ) as gql_session:
+
+            query = gql(
+                """
+                mutation deletePipeline($id: String!) {
+                  deletePipeline(id: $id) {
+                    id
+                    name
+                    describe
+                    dataCatalog {
+                      name
+                      config
+                      tags {
+                        key
+                        value
+                      }
+                    }
+                    nodes {
+                      name
+                      inputs
+                      outputs
+                      tags
+                    }
+                    parameters {
+                      name
+                      value
+                      type
+                    }
+                    status {
+                      session
+                      state
+                      runner
+                      startedAt
+                      finishedAt
+                      taskId
+                      taskName
+                      taskArgs
+                      taskKwargs
+                      taskRequest
+                      taskException
+                      taskTraceback
+                      taskEinfo
+                      taskResult
+                    }
+                    tags {
+                      key
+                      value
+                    }
+ 
+                  }
+                }
+            """
+            )
+            result = await gql_session.execute(query, variable_values={"id": str(id)})
+            return Pipeline.decode(result["deletePipeline"], decoder="graphql")
+
+    async def pipeline_events(self, id: str = None):
+        """Subscribe to pipeline events.
+
+        Kwargs:
+            id (str): pipeline id
+
+        Returns:
+            PipelineEvent (generator): a generator of PipelineEvent objects
+        """
+
+        async with Client(
+            transport=self._web_transport,
+        ) as gql_session:
+
+            query = gql(
+                """
+                subscription pipelineEvents($id: String!) {
+                  pipeline(id: $id) {
+                    id
+                    taskId
+                    status
+                    result
+                    timestamp
+                    traceback
+                  }
+                }
+            """
+            )
+
+            async for result in gql_session.subscribe(query, variable_values={"id": str(id)}):
+                yield PipelineEvent.decode(result, decoder="graphql")
+
+    async def pipeline_logs(self, id: str = None):
+        """Subscribe to pipeline logs.
+
+        Kwargs:
+            id (str): pipeline id
+
+        Returns:
+            PipelineLogMessage (generator): a generator of PipelineLogMessage objects
+        """
+
+        async with Client(
+            transport=self._web_transport,
+        ) as gql_session:
+
+            query = gql(
+                """
+                subscription pipelineLogs($id: String!) {
+                  pipelineLogs(id: $id) {
+                    id
+                    message
+                    messageId
+                    taskId
+                    time
+                  }
+                }
+            """
+            )
+            async for result in gql_session.subscribe(query, variable_values={"id": str(id)}):
+                yield PipelineLogMessage.decode(result, decoder="graphql")

--- a/src/kedro_graphql/client.py
+++ b/src/kedro_graphql/client.py
@@ -54,7 +54,7 @@ PIPELINE_GQL = """{
 
 class KedroGraphqlClient():
 
-    def __init__(self, uri=None, ws=None):
+    def __init__(self, uri=None, ws=None, pipeline_gql=None):
         """
         Kwargs:
             uri (str): uri to api [default: http://localhost:5000/graphql]
@@ -68,6 +68,7 @@ class KedroGraphqlClient():
         self._aio_session = None
         self._web_client = Client(transport=self._web_transport)
         self._web_session = None
+        self.pipeline_gql = pipeline_gql or PIPELINE_GQL
 
     async def create_pipeline(self, pipeline_input: PipelineInput = None):
         """Create a pipeline
@@ -85,7 +86,7 @@ class KedroGraphqlClient():
             query = gql(
                 """
                 mutation createPipeline($pipeline: PipelineInput!) {
-                  createPipeline(pipeline: $pipeline) """ + PIPELINE_GQL + """
+                  createPipeline(pipeline: $pipeline) """ + self.pipeline_gql + """
                 }
             """
             )
@@ -108,14 +109,14 @@ class KedroGraphqlClient():
             query = gql(
                 """
                 query readPipeline($id: String!) {
-                  readPipeline(id: $id) """ + PIPELINE_GQL + """
+                  readPipeline(id: $id) """ + self.pipeline_gql + """
                 }
             """
             )
             result = await gql_session.execute(query, variable_values={"id": str(id)})
             return Pipeline.decode(result["readPipeline"], decoder="graphql")
 
-    async def read_pipelines(self, limit: int = 10, cursor: str = None, filter: str = None):
+    async def read_pipelines(self, limit: int = 10, cursor: str = None, filter: str = "", sort: str = ""):
         """Read pipelines.
 
         Kwargs:
@@ -133,17 +134,17 @@ class KedroGraphqlClient():
 
             query = gql(
                 """
-                query readPipelines($limit: Int!, $cursor: String, $filter: String!) {
-                  readPipelines(limit: $limit, cursor: $cursor, filter: $filter) { 
+                query readPipelines($limit: Int!, $cursor: String, $filter: String, $sort: String) {
+                  readPipelines(limit: $limit, cursor: $cursor, filter: $filter, sort: $sort) { 
                     pageMeta {
                       nextCursor
                     }
-                    pipelines """ + PIPELINE_GQL + """
+                    pipelines """ + self.pipeline_gql + """
                   }
                 }
             """
             )
-            result = await gql_session.execute(query, variable_values={"limit": limit, "cursor": cursor, "filter": filter})
+            result = await gql_session.execute(query, variable_values={"limit": limit, "cursor": cursor, "filter": filter, "sort": sort})
             return Pipelines.decode(result, decoder="graphql")
 
     async def update_pipeline(self, id: str = None, pipeline_input: PipelineInput = None):
@@ -163,50 +164,7 @@ class KedroGraphqlClient():
             query = gql(
                 """
                 mutation updatePipeline($id: String!, $pipeline: PipelineInput!) {
-                  updatePipeline(id: $id, pipeline: $pipeline) {
-                    id
-                    name
-                    describe
-                    dataCatalog {
-                      name
-                      config
-                      tags {
-                        key
-                        value
-                      }
-                    }
-                    nodes {
-                      name
-                      inputs
-                      outputs
-                      tags
-                    }
-                    parameters {
-                      name
-                      value
-                      type
-                    }
-                    status {
-                      session
-                      state
-                      runner
-                      startedAt
-                      finishedAt
-                      taskId
-                      taskName
-                      taskArgs
-                      taskKwargs
-                      taskRequest
-                      taskException
-                      taskTraceback
-                      taskEinfo
-                      taskResult
-                    }
-                    tags {
-                      key
-                      value
-                    }
-                  }
+                  updatePipeline(id: $id, pipeline: $pipeline) """ + self.pipeline_gql + """
                 }
             """
             )
@@ -230,51 +188,7 @@ class KedroGraphqlClient():
             query = gql(
                 """
                 mutation deletePipeline($id: String!) {
-                  deletePipeline(id: $id) {
-                    id
-                    name
-                    describe
-                    dataCatalog {
-                      name
-                      config
-                      tags {
-                        key
-                        value
-                      }
-                    }
-                    nodes {
-                      name
-                      inputs
-                      outputs
-                      tags
-                    }
-                    parameters {
-                      name
-                      value
-                      type
-                    }
-                    status {
-                      session
-                      state
-                      runner
-                      startedAt
-                      finishedAt
-                      taskId
-                      taskName
-                      taskArgs
-                      taskKwargs
-                      taskRequest
-                      taskException
-                      taskTraceback
-                      taskEinfo
-                      taskResult
-                    }
-                    tags {
-                      key
-                      value
-                    }
- 
-                  }
+                  deletePipeline(id: $id) """ + self.pipeline_gql + """ 
                 }
             """
             )

--- a/src/kedro_graphql/commands.py
+++ b/src/kedro_graphql/commands.py
@@ -152,18 +152,21 @@ def gql(metadata, app, backend, broker, celery_result_backend, conf_source,
         reload_path = metadata.project_path.joinpath("src")
 
     if reload:
-        logger.info("AUTO-RELOAD ACTIVATED, watching '" + str(reload_path) + "' for changes")
+        logger.info("AUTO-RELOAD ACTIVATED, watching '" +
+                    str(reload_path) + "' for changes")
 
     if worker:
         if reload:
             run_process(str(reload_path), target=start_worker, args=(
                 app, config, conf_source, env, metadata.package_name, metadata.project_path))
         else:
-            start_worker(app, config, conf_source, env, metadata.package_name, metadata.project_path)
+            start_worker(app, config, conf_source, env,
+                         metadata.package_name, metadata.project_path)
 
     else:
         if reload:
             run_process(reload_path, target=start_app, args=(app, config, conf_source,
                         env, metadata.package_name, metadata.project_path))
         else:
-            start_app(app, config, conf_source, env, metadata.package_name, metadata.project_path)
+            start_app(app, config, conf_source, env,
+                      metadata.package_name, metadata.project_path)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,3 +20,4 @@ fastapi~=0.111.0
 pymongo~=4.7.2
 python-dotenv~=1.0.1
 pytest-asyncio~=0.23.7
+gql~=3.5.1

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -37,7 +37,6 @@ def start_server():
 def setup():
     proc = Process(target=start_server, args=())
     proc.start()
-    time.sleep(2)
     yield
     proc.terminate()
 

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -29,7 +29,7 @@ def start_server():
             app.config["KEDRO_GRAPHQL_LOG_PATH_PREFIX"] = tmp
             app.config["KEDRO_GRAPHQL_LOG_TMP_DIR"] = tmp2
             uvicorn.run(app,
-                        host="0.0.0.0",
+                        host="localhost",
                         port=5000)
 
 
@@ -44,8 +44,8 @@ def setup():
 
 @pytest.fixture
 def mock_client(setup):
-    return KedroGraphqlClient(uri="http://0.0.0.0:5000/graphql",
-                              ws="ws://0.0.0.0:5000/graphql")
+    return KedroGraphqlClient(uri="http://localhost:5000/graphql",
+                              ws="ws://localhost:5000/graphql")
 
 
 @pytest.fixture
@@ -178,8 +178,6 @@ class TestKedroGraphqlClient:
 
         async for result in mock_client.pipeline_events(id=pipeline.id):
             assert result.status in ALL_STATES
-            if result.status == "SUCCESS":
-                break
 
     @pytest.mark.usefixtures('mock_celery_session_app')
     @pytest.mark.usefixtures('celery_session_worker')

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -1,0 +1,193 @@
+import pytest
+from kedro.framework.session import KedroSession
+from kedro.framework.startup import bootstrap_project
+from kedro_graphql.client import KedroGraphqlClient
+from kedro_graphql.models import PipelineInput, Pipeline, TagInput
+from multiprocessing import Process
+import uvicorn
+import time
+import json
+from pathlib import Path
+from kedro_graphql.asgi import KedroGraphQL
+from celery.states import ALL_STATES
+from kedro_graphql.schema import encode_cursor
+import multiprocessing as mp
+import tempfile
+
+
+if mp.get_start_method(allow_none=True) != "spawn":
+    mp.set_start_method("spawn")
+
+
+def start_server():
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp2:
+            bootstrap_project(Path.cwd())
+            session = KedroSession.create()
+            app = KedroGraphQL(kedro_session=session)
+            app.config["KEDRO_GRAPHQL_LOG_PATH_PREFIX"] = tmp
+            app.config["KEDRO_GRAPHQL_LOG_TMP_DIR"] = tmp2
+            uvicorn.run(app,
+                        host="0.0.0.0",
+                        port=5000)
+
+
+@pytest.fixture(scope="session")
+def setup():
+    proc = Process(target=start_server, args=())
+    proc.start()
+    time.sleep(2)
+    yield
+    proc.terminate()
+
+
+@pytest.fixture
+def mock_client(setup):
+    return KedroGraphqlClient(uri="http://0.0.0.0:5000/graphql",
+                              ws="ws://0.0.0.0:5000/graphql")
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def mock_create_pipeline(mock_client, mock_text_in, mock_text_out):
+
+    input_dict = {"type": "text.TextDataset", "filepath": str(mock_text_in)}
+    output_dict = {"type": "text.TextDataset", "filepath": str(mock_text_out)}
+
+    pipeline_input = PipelineInput(**{
+        "name": "example00",
+        "state": "READY",
+        "data_catalog": [{"name": "text_in", "config": json.dumps(input_dict)},
+                         {"name": "text_out", "config": json.dumps(output_dict)}],
+        "parameters": [{"name": "example", "value": "hello"},
+                       {"name": "duration", "value": "0", "type": "FLOAT"}],
+        "tags": [{"key": "author", "value": "opensean"},
+                 {"key": "package", "value": "kedro-graphql"}]
+    })
+    expected = Pipeline.decode(pipeline_input)
+    pipeline = await mock_client.create_pipeline(pipeline_input)
+    return pipeline_input, expected, pipeline
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def mock_create_pipeline_staged(mock_client, mock_text_in, mock_text_out):
+
+    input_dict = {"type": "text.TextDataset", "filepath": str(mock_text_in)}
+    output_dict = {"type": "text.TextDataset", "filepath": str(mock_text_out)}
+
+    pipeline_input = PipelineInput(**{
+        "name": "example00",
+        "state": "STAGED",
+        "data_catalog": [{"name": "text_in", "config": json.dumps(input_dict)},
+                         {"name": "text_out", "config": json.dumps(output_dict)}],
+        "parameters": [{"name": "example", "value": "hello"},
+                       {"name": "duration", "value": "0", "type": "FLOAT"}],
+        "tags": [{"key": "author", "value": "opensean"},
+                 {"key": "package", "value": "kedro-graphql"}]
+    })
+
+    expected = Pipeline.decode(pipeline_input)
+    pipeline = await mock_client.create_pipeline(pipeline_input)
+    return pipeline_input, expected, pipeline
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def mock_create_pipeline_staged_unique(mock_client, mock_text_in, mock_text_out):
+
+    input_dict = {"type": "text.TextDataset", "filepath": str(mock_text_in)}
+    output_dict = {"type": "text.TextDataset", "filepath": str(mock_text_out)}
+
+    pipeline_input = PipelineInput(**{
+        "name": "example00",
+        "state": "STAGED",
+        "data_catalog": [{"name": "text_in", "config": json.dumps(input_dict)},
+                         {"name": "text_out", "config": json.dumps(output_dict)}],
+        "parameters": [{"name": "example", "value": "hello"},
+                       {"name": "duration", "value": "0", "type": "FLOAT"}],
+        "tags": [{"key": "author", "value": "opensean"},
+                 {"key": "package", "value": "kedro-graphql"},
+                 {"key": "unique", "value": "unique"}]
+    })
+
+    expected = Pipeline.decode(pipeline_input)
+    pipeline = await mock_client.create_pipeline(pipeline_input)
+    return pipeline_input, expected, pipeline
+
+
+class TestKedroGraphqlClient:
+
+    @pytest.mark.asyncio
+    async def test_create_pipeline(self, mock_create_pipeline_staged):
+
+        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+
+        assert pipeline.name == expected.name
+        assert pipeline.data_catalog == expected.data_catalog
+        assert pipeline.parameters == expected.parameters
+        assert pipeline.tags == expected.tags
+
+    @pytest.mark.asyncio
+    async def test_read_pipeline(self, mock_create_pipeline_staged, mock_client):
+
+        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+        r = await mock_client.read_pipeline(id=pipeline.id)
+        assert r.name == expected.name
+        assert r.data_catalog == expected.data_catalog
+        assert r.parameters == expected.parameters
+        assert r.tags == expected.tags
+
+    @pytest.mark.asyncio
+    async def test_read_pipelines(self, mock_create_pipeline_staged_unique, mock_client):
+
+        pipeline_input, expected, pipeline = await mock_create_pipeline_staged_unique
+        limit = 1
+        filter = "{\"tags.key\": \"unique\", \"tags.value\": \"unique\"}"
+        cursor = encode_cursor(pipeline.id)
+        r = await mock_client.read_pipelines(filter=filter, limit=limit, cursor=cursor)
+        assert r.pipelines[0].name == expected.name
+        assert r.pipelines[0].data_catalog == expected.data_catalog
+        assert r.pipelines[0].parameters == expected.parameters
+        assert r.pipelines[0].tags == expected.tags
+
+    @pytest.mark.asyncio
+    async def test_update_pipeline(self, mock_create_pipeline_staged, mock_client):
+
+        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+        pipeline_input.tags.append(TagInput(key="test-update", value="updated"))
+        r = await mock_client.update_pipeline(id=pipeline.id, pipeline_input=pipeline_input)
+        assert r.tags[-1].key == "test-update"
+        assert r.tags[-1].value == "updated"
+
+    @pytest.mark.asyncio
+    async def test_delete_pipeline(self, mock_create_pipeline_staged, mock_client):
+
+        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+        r = await mock_client.delete_pipeline(id=pipeline.id)
+        assert r.id == pipeline.id
+
+    @pytest.mark.usefixtures('mock_celery_session_app')
+    @pytest.mark.usefixtures('celery_session_worker')
+    @pytest.mark.usefixtures('depends_on_current_app')
+    @pytest.mark.asyncio
+    async def test_pipeline_events(self, mock_create_pipeline, mock_client):
+
+        pipeline_input, expected, pipeline = await mock_create_pipeline
+
+        async for result in mock_client.pipeline_events(id=pipeline.id):
+            assert result.status in ALL_STATES
+            if result.status == "SUCCESS":
+                break
+
+    @pytest.mark.usefixtures('mock_celery_session_app')
+    @pytest.mark.usefixtures('celery_session_worker')
+    @pytest.mark.usefixtures('depends_on_current_app')
+    @pytest.mark.asyncio
+    async def test_pipeline_logs(self, mock_create_pipeline, mock_client):
+
+        pipeline_input, expected, pipeline = await mock_create_pipeline
+
+        async for result in mock_client.pipeline_logs(id=pipeline.id):
+            assert result.id == pipeline.id

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -2,10 +2,10 @@ import pytest
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import bootstrap_project
 from kedro_graphql.client import KedroGraphqlClient
+from kedro_graphql.config import config as CONFIG
 from kedro_graphql.models import PipelineInput, Pipeline, TagInput
 from multiprocessing import Process
 import uvicorn
-import time
 import json
 from pathlib import Path
 from kedro_graphql.asgi import KedroGraphQL
@@ -13,6 +13,7 @@ from celery.states import ALL_STATES
 from kedro_graphql.schema import encode_cursor
 import multiprocessing as mp
 import tempfile
+import pytest_asyncio
 
 
 if mp.get_start_method(allow_none=True) != "spawn":
@@ -25,7 +26,7 @@ def start_server():
         with tempfile.TemporaryDirectory() as tmp2:
             bootstrap_project(Path.cwd())
             session = KedroSession.create()
-            app = KedroGraphQL(kedro_session=session)
+            app = KedroGraphQL(kedro_session=session, config=CONFIG)
             app.config["KEDRO_GRAPHQL_LOG_PATH_PREFIX"] = tmp
             app.config["KEDRO_GRAPHQL_LOG_TMP_DIR"] = tmp2
             uvicorn.run(app,
@@ -33,7 +34,7 @@ def start_server():
                         port=5000)
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 def setup():
     proc = Process(target=start_server, args=())
     proc.start()
@@ -41,14 +42,15 @@ def setup():
     proc.terminate()
 
 
-@pytest.fixture
-def mock_client(setup):
-    return KedroGraphqlClient(uri="http://localhost:5000/graphql",
-                              ws="ws://localhost:5000/graphql")
+@pytest_asyncio.fixture
+async def mock_client(setup):
+    client = KedroGraphqlClient(uri="http://localhost:5000/graphql",
+                                ws="ws://localhost:5000/graphql")
+    yield client
+    await client.close_sessions()
 
 
-@pytest.fixture
-@pytest.mark.asyncio
+@pytest_asyncio.fixture
 async def mock_create_pipeline(mock_client, mock_text_in, mock_text_out):
 
     input_dict = {"type": "text.TextDataset", "filepath": str(mock_text_in)}
@@ -69,8 +71,7 @@ async def mock_create_pipeline(mock_client, mock_text_in, mock_text_out):
     return pipeline_input, expected, pipeline
 
 
-@pytest.fixture
-@pytest.mark.asyncio
+@pytest_asyncio.fixture
 async def mock_create_pipeline_staged(mock_client, mock_text_in, mock_text_out):
 
     input_dict = {"type": "text.TextDataset", "filepath": str(mock_text_in)}
@@ -92,8 +93,7 @@ async def mock_create_pipeline_staged(mock_client, mock_text_in, mock_text_out):
     return pipeline_input, expected, pipeline
 
 
-@pytest.fixture
-@pytest.mark.asyncio
+@pytest_asyncio.fixture
 async def mock_create_pipeline_staged_unique(mock_client, mock_text_in, mock_text_out):
 
     input_dict = {"type": "text.TextDataset", "filepath": str(mock_text_in)}
@@ -121,7 +121,7 @@ class TestKedroGraphqlClient:
     @pytest.mark.asyncio
     async def test_create_pipeline(self, mock_create_pipeline_staged):
 
-        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+        pipeline_input, expected, pipeline = mock_create_pipeline_staged
 
         assert pipeline.name == expected.name
         assert pipeline.data_catalog == expected.data_catalog
@@ -131,7 +131,7 @@ class TestKedroGraphqlClient:
     @pytest.mark.asyncio
     async def test_read_pipeline(self, mock_create_pipeline_staged, mock_client):
 
-        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+        pipeline_input, expected, pipeline = mock_create_pipeline_staged
         r = await mock_client.read_pipeline(id=pipeline.id)
         assert r.name == expected.name
         assert r.data_catalog == expected.data_catalog
@@ -141,7 +141,7 @@ class TestKedroGraphqlClient:
     @pytest.mark.asyncio
     async def test_read_pipelines(self, mock_create_pipeline_staged_unique, mock_client):
 
-        pipeline_input, expected, pipeline = await mock_create_pipeline_staged_unique
+        pipeline_input, expected, pipeline = mock_create_pipeline_staged_unique
         limit = 1
         filter = "{\"tags.key\": \"unique\", \"tags.value\": \"unique\"}"
         cursor = encode_cursor(pipeline.id)
@@ -155,7 +155,7 @@ class TestKedroGraphqlClient:
     @pytest.mark.asyncio
     async def test_update_pipeline(self, mock_create_pipeline_staged, mock_client):
 
-        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+        pipeline_input, expected, pipeline = mock_create_pipeline_staged
         pipeline_input.tags.append(TagInput(key="test-update", value="updated"))
         r = await mock_client.update_pipeline(id=pipeline.id, pipeline_input=pipeline_input)
         assert r.tags[-1].key == "test-update"
@@ -164,7 +164,7 @@ class TestKedroGraphqlClient:
     @pytest.mark.asyncio
     async def test_delete_pipeline(self, mock_create_pipeline_staged, mock_client):
 
-        pipeline_input, expected, pipeline = await mock_create_pipeline_staged
+        pipeline_input, expected, pipeline = mock_create_pipeline_staged
         r = await mock_client.delete_pipeline(id=pipeline.id)
         assert r.id == pipeline.id
 
@@ -174,7 +174,7 @@ class TestKedroGraphqlClient:
     @pytest.mark.asyncio
     async def test_pipeline_events(self, mock_create_pipeline, mock_client):
 
-        pipeline_input, expected, pipeline = await mock_create_pipeline
+        pipeline_input, expected, pipeline = mock_create_pipeline
 
         async for result in mock_client.pipeline_events(id=pipeline.id):
             assert result.status in ALL_STATES
@@ -185,7 +185,7 @@ class TestKedroGraphqlClient:
     @pytest.mark.asyncio
     async def test_pipeline_logs(self, mock_create_pipeline, mock_client):
 
-        pipeline_input, expected, pipeline = await mock_create_pipeline
+        pipeline_input, expected, pipeline = mock_create_pipeline
 
         async for result in mock_client.pipeline_logs(id=pipeline.id):
             assert result.id == pipeline.id

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -146,7 +146,8 @@ class TestKedroGraphqlClient:
         limit = 1
         filter = "{\"tags.key\": \"unique\", \"tags.value\": \"unique\"}"
         cursor = encode_cursor(pipeline.id)
-        r = await mock_client.read_pipelines(filter=filter, limit=limit, cursor=cursor)
+        sort = "[(\"created_at\", -1)]"
+        r = await mock_client.read_pipelines(filter=filter, limit=limit, cursor=cursor, sort=sort)
         assert r.pipelines[0].name == expected.name
         assert r.pipelines[0].data_catalog == expected.data_catalog
         assert r.pipelines[0].parameters == expected.parameters


### PR DESCRIPTION
Added

- a python client with CRUD support to facilitate integration with other python applications 
  ```
  import json
  from kedro_graphql.models import Pipeline, PipelineInput, TagInput
  from kedro_graphl.client import KedroGraphqlClient
  
  client = KedroGraphqlClient(uri="http://0.0.0.0:5000/graphql",
                              ws="ws://0.0.0.0:5000/graphql")
  
  input_dict = {"type": "text.TextDataset", "filepath": "s3://example/text_in.txt"}
  output_dict = {"type": "text.TextDataset", "filepath": "s3://example/text_out.txt"}

  pipeline_input = PipelineInput(**{
      "name": "example00",
      "state": "STAGED",
      "data_catalog": [{"name": "text_in", "config": json.dumps(input_dict)},
                       {"name": "text_out", "config": json.dumps(output_dict)}],
      "parameters": [{"name": "example", "value": "hello"},
                     {"name": "duration", "value": "0", "type": "FLOAT"}],
      "tags": [{"key": "author", "value": "opensean"},
               {"key": "package", "value": "kedro-graphql"}]
  })

  ## create a pipeline
  pipeline = await client.create_pipeline(pipeline_input)

  ## read a pipeline
  pipeline = await client.read_pipeline(id=pipeline.id)

  ## read pipelines
  pipelines = await client.read_pipelines(limit=5, filter="{\"tags.key\": \"package\", \"tags.value\": \"kedro-graphql\"}")

  ## update a pipeline
  pipeline_input.tags.append(TagInput(key="test-update", value="updated"))
  pipeline = await client.update_pipeline(id=pipeline.id, pipeline_input=pipeline_input)

  ## delete a pipeline
  pipeline = await client.delete_pipeline(id=pipeline.id)
  ```
- [gql](https://gql.readthedocs.io/en/stable/) dependency in requirements.txt for the client
- a `def delete_pipeline_collection` pytest fixture that will drop the "pipelines" collection after all tests have finished
- encode and decode functions for the Pipelines, Pipeline, PipelineEvent, PipelineLogs, and PipelineInput objects 

Changed

- using python's tempfile in pytest fixtures for efficient cleanup after testing
- Removed the private `kedro_pipelines_index` field from the Pipeline object to decouple from application
  - the `nodes` and `describe` fields of the Pipeline object are now set when the `create_pipeline` mutation is called rather than resovled upon query