### PR TITLE
Add strawberry build schema kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Added
 - [gql](https://gql.readthedocs.io/en/stable/) dependency in requirements.txt for the client
 - a `def delete_pipeline_collection` pytest fixture that will drop the "pipelines" collection after all tests have finished
 - encode and decode functions for the Pipelines, Pipeline, PipelineEvent, PipelineLogs, and PipelineInput objects
+- support for native `strawberry.Schema` keyword arguments in `kedro_graphql.schema.build_schema` wrapper
 
 Changed
 

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -2,8 +2,8 @@ import asyncio
 from base64 import b64decode, b64encode
 from datetime import datetime
 from importlib import import_module
-from typing import AsyncGenerator, Optional, Union
-from collections.abc import AsyncGenerator,  Iterable
+from typing import Optional, Union
+from collections.abc import AsyncGenerator, Iterable
 from graphql.execution import ExecutionContext as GraphQLExecutionContext
 
 import strawberry


### PR DESCRIPTION
I need to be able to pass in schema extensions in the schema constructor for my use case (i.e. I want to add the `NoSchemaIntrospectionCustomRule` [documented here](https://strawberry.rocks/docs/extensions/add-validation-rules#more-examples)) but I want to still use the kedro graphql `build_schema` wrapper function.

Added

- The kwargs [found here](https://github.com/strawberry-graphql/strawberry/blob/0d9ffa5259c0316c1bcff7ca79f5ebab739a5924/strawberry/schema/schema.py#L139-L155) to `build_schema` 