### PR TITLE
Refactor/panel spec fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [Unreleased]
+
+Added:
+
+- command-line flags for all configuration options, including complex data types support using JSON strings
+- proper configuration loading order (YAML spec > CLI flags > Environment variables > .env file > Defaults)
+- support for comma-separated strings, JSON arrays, and single values for list-type configuration options
+- `test_config.py` with unit tests for configuration precedence and data type parsing scenarios
+- `root_path` configuration option to support API endpoint prefixing
+- support for both `X-Forwarded-*` and `x-auth-request-*` header formats for OAuth2 proxy compatibility
+
+Changed:
+
+- `configuration.md` with alphabetical ordering and detailed examples for different data types
+- alphabetically sorted all spec-*.yaml files
+- some panel UI components for better async handling and loading states using `pn.state.onload`
+
+Removed:
+
+- some outdated documentation
+
+Fixed:
+
+- proper error handling in load_api_spec() to prevent crashes on YAML parsing errors
+- race conditions in Panel components by ensuring proper loading order
+- S3 provider key handling for files without directory prefixes
+- panel server kwargs configuration in UI specs
 
 ## [1.1.1] - 2025-08-01
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ The following table describes each configuration attribute available:
 | `local_file_provider_upload_allowed_roots`   | list | `["./data"]` | List of allowed root directories for uploads. Can be specified as comma-separated string or JSON array. |
 | `local_file_provider_upload_max_file_size_mb` | integer | `10` | Maximum allowed upload file size in megabytes. |
 | `log_path_prefix`                      | string | `None` | Optional prefix for log file paths.                                                              |
-| `log_tmp_dir`                          | string | auto-generated | Directory path for temporary log files.                                                          |
+| `log_tmp_dir`                          | string | `tempfile.TemporaryDirectory().name` | Directory path for temporary log files.                                                          |
 | `mongo_db_collection`                   | string | `pipelines` | Name of the MongoDB collection to use.                                                           |
 | `mongo_db_name`                        | string | `pipelines` | Name of the MongoDB database to use.                                                             |
 | `mongo_uri`                            | string | `mongodb://root:example@localhost:27017/` | MongoDB connection URI string.                                                                   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ The following table describes each configuration attribute available:
 | `deprecation_docs`                     | URL to documentation about deprecated features.                                                  |
 | `log_tmp_dir`                          | Directory path for temporary log files.                                                          |
 | `log_path_prefix`                      | Optional prefix for log file paths.                                                              |
+| `root_path`                            | Root path for all API endpoints (e.g., '/api/v1'). When set, all API routes will be prefixed with this path. |
 | `signed_url_max_expires_in_sec`    | Maximum allowed expiration time (in seconds) for presigned URLs. Default: `43200` (12 hours). |
 | `local_file_provider_server_url`       | Base URL for the local file server (e.g., `http://localhost:5000`).                             |
 | `local_file_provider_jwt_secret_key`   | Secret key for signing JWT tokens for local file access.                                        |
@@ -61,6 +62,7 @@ KEDRO_GRAPHQL_ENV=local
 KEDRO_GRAPHQL_CONF_SOURCE=None
 KEDRO_GRAPHQL_LOG_TMP_DIR=my_tmp_dir/
 KEDRO_GRAPHQL_LOG_PATH_PREFIX=s3://my-bucket/
+KEDRO_GRAPHQL_ROOT_PATH=/api/v1
 KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC=43200
 KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_SERVER_URL=http://localhost:5000
 KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_JWT_SECRET_KEY=your_secret_key
@@ -91,6 +93,7 @@ for the remaining string.  For example:
 | conf_source                | --conf-source        | $HOME/myproject/conf                      |
 | log_tmp_dir                | --log-tmp-dir        | my_tmp_dir/                               |
 | log_path_prefix            | --log-path-prefix    | s3://my-bucket/                           |
+| root_path                  | --root-path          | /api/v1                                   |
 
 
 ## YAML API Specification
@@ -118,6 +121,7 @@ config:
   deprecation_docs: "https://github.com/opensean/kedro-graphql/blob/main/README.md#deprecations"
   log_tmp_dir: "/tmp/"
   log_path_prefix: null
+  root_path: null
   events_config:
     event00:
       source: "example.com"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,132 +1,166 @@
 The following table describes each configuration attribute available:
 
-| Attribute                              | Description                                                                                      |
-|-----------------------------------------|--------------------------------------------------------------------------------------------------|
-| `mongo_uri`                            | MongoDB connection URI string.                                                                   |
-| `mongo_db_name`                        | Name of the MongoDB database to use.                                                             |
-| `mongo_db_collection`                   | Name of the MongoDB collection to use.                                                           |
-| `imports`                              | List of Python modules to import for plugin registration.                                        |
-| `app`                                  | Python path to the ASGI application callable.                                                    |
-| `app_title`                            | Title of the Kedro GraphQL application.                                                          |
-| `app_description`                      | Description of the Kedro GraphQL application.                                                    |
-| `project_version`                      | Version of the Kedro GraphQL project.                                                            |
-| `backend`                              | Python path to the backend class for data storage and retrieval.                                 |
-| `broker`                               | URI for the message broker (e.g., Redis) used for task queueing.                                |
-| `celery_result_backend`                 | URI for the Celery result backend (e.g., Redis).                                                 |
-| `runner`                               | Python path to the Kedro runner class.                                                           |
-| `env`                                  | Environment name (e.g., "local").                                                                |
-| `conf_source`                          | Optional path to an alternative configuration source.                                             |
-| `deprecation_docs`                     | URL to documentation about deprecated features.                                                  |
-| `log_tmp_dir`                          | Directory path for temporary log files.                                                          |
-| `log_path_prefix`                      | Optional prefix for log file paths.                                                              |
-| `root_path`                            | Root path for all API endpoints (e.g., '/api/v1'). When set, all API routes will be prefixed with this path. |
-| `signed_url_max_expires_in_sec`    | Maximum allowed expiration time (in seconds) for presigned URLs. Default: `43200` (12 hours). |
-| `local_file_provider_server_url`       | Base URL for the local file server (e.g., `http://localhost:5000`).                             |
-| `local_file_provider_jwt_secret_key`   | Secret key for signing JWT tokens for local file access.                                        |
-| `local_file_provider_jwt_algorithm`    | Algorithm used for JWT signing (e.g., `HS256`).                                                |
-| `local_file_provider_download_allowed_roots` | List of allowed root directories for downloads.                                          |
-| `local_file_provider_upload_allowed_roots`   | List of allowed root directories for uploads.                                            |
-| `local_file_provider_upload_max_file_size_mb` | Maximum allowed upload file size in megabytes. Default: `10`.                            |
-| `events_config`                        | Dictionary for event configuration.                                                              |
-| `permissions`                          | Python path to the permissions class used for authentication.                                    |
-| `permissions_role_to_action_map`       | Mapping of roles to allowed actions.                                                              |
-| `permissions_group_to_role_map`        | Mapping of external group names to roles.                                                        |
-| `signed_url_provider`                  | Python path to the presigned URL provider class (e.g., for S3 or local file support). |
+| Attribute                              | Type | Default | Description                                                                                      |
+|-----------------------------------------|------|---------|--------------------------------------------------------------------------------------------------|
+| `app`                                  | string | `kedro_graphql.asgi.KedroGraphQL` | Python path to the ASGI application callable.                                                    |
+| `app_description`                      | string | `A tool for serving kedro projects as a GraphQL API` | Description of the Kedro GraphQL application.                                                    |
+| `app_title`                            | string | `Kedro GraphQL API` | Title of the Kedro GraphQL application.                                                          |
+| `backend`                              | string | `kedro_graphql.backends.mongodb.MongoBackend` | Python path to the backend class for data storage and retrieval.                                 |
+| `broker`                               | string | `redis://localhost` | URI for the message broker (e.g., Redis) used for task queueing.                                |
+| `celery_result_backend`                 | string | `redis://localhost` | URI for the Celery result backend (e.g., Redis).                                                 |
+| `conf_source`                          | string | `None` | Optional path to an alternative configuration source.                                             |
+| `deprecations_docs`                     | string | `""` | Optional URL to documentation about deprecated features.                                          |
+| `env`                                  | string | `local` | Environment name (e.g., "local").                                                                |
+| `events_config`                        | dict | `None` | Dictionary for event configuration. Specify as JSON string when using CLI/environment variables. |
+| `imports`                              | list | `["kedro_graphql.plugins.plugins"]` | List of Python modules to import for plugin registration. Can be specified as comma-separated string or JSON array. |
+| `local_file_provider_download_allowed_roots` | list | `["./data", "/var", "/tmp"]` | List of allowed root directories for downloads. Can be specified as comma-separated string or JSON array. |
+| `local_file_provider_jwt_algorithm`    | string | `HS256` | Algorithm used for JWT signing.                                                |
+| `local_file_provider_jwt_secret_key`   | string | `my-secret-key` | Secret key for signing JWT tokens for local file access.                                        |
+| `local_file_provider_server_url`       | string | `http://localhost:5000` | Base URL for the local file server.                             |
+| `local_file_provider_upload_allowed_roots`   | list | `["./data"]` | List of allowed root directories for uploads. Can be specified as comma-separated string or JSON array. |
+| `local_file_provider_upload_max_file_size_mb` | integer | `10` | Maximum allowed upload file size in megabytes. |
+| `log_path_prefix`                      | string | `None` | Optional prefix for log file paths.                                                              |
+| `log_tmp_dir`                          | string | auto-generated | Directory path for temporary log files.                                                          |
+| `mongo_db_collection`                   | string | `pipelines` | Name of the MongoDB collection to use.                                                           |
+| `mongo_db_name`                        | string | `pipelines` | Name of the MongoDB database to use.                                                             |
+| `mongo_uri`                            | string | `mongodb://root:example@localhost:27017/` | MongoDB connection URI string.                                                                   |
+| `permissions`                          | string | `kedro_graphql.permissions.IsAuthenticatedAlways` | Python path to the permissions class used for authentication.                                    |
+| `permissions_group_to_role_map`        | dict | `{"EXTERNAL_GROUP_NAME": "admin"}` | Mapping of external group names to roles. Specify as JSON string when using CLI/environment variables. |
+| `permissions_role_to_action_map`       | dict | `{"admin": [...]}` | Mapping of roles to allowed actions. Specify as JSON string when using CLI/environment variables. |
+| `project_version`                      | string | `None` | Version of the Kedro GraphQL project.                                                            |
+| `root_path`                            | string | `""` | Root path for all API endpoints (e.g., '/api/v1'). When set, all API routes will be prefixed with this path. |
+| `runner`                               | string | `kedro.runner.SequentialRunner` | Python path to the Kedro runner class.                                                           |
+| `signed_url_max_expires_in_sec`    | integer | `43200` | Maximum allowed expiration time (in seconds) for presigned URLs. Default: 12 hours. |
+| `signed_url_provider`                  | string | `kedro_graphql.signed_url.s3_provider.S3Provider` | Python path to the presigned URL provider class (e.g., for S3 or local file support). |
 
 
 
 Configuration can be supplied through one or more of the following methods:
 
+- [YAML API Spec](#yaml-api-specification)
+- [command line](#command-line)
 - [environment](#environment)
 - ```.env``` file
-- [command line](#commandline)
-- [YAML API Spec](##yamlapispec)
 
+## Data Types and Formats
 
-## Environment
+Kedro GraphQL supports flexible configuration formats for different data types:
 
-When using environment varialbes the configration attribute name should
-be uppercase and prefixed with `KEDRO_GRAPHQL_`
+Simple string values can be provided directly:
 
 ```bash
-## example .env file
-KEDRO_GRAPHQL_MONGO_URI=mongodb://root:example@localhost:27017/
-KEDRO_GRAPQHL_MONGO_DB_NAME=pipelines
-KEDRO_GRAPHQL_IMPORTS=kedro_graphql.plugins.plugins
-KEDRO_GRAPHQL_APP=kedro_graphql.asgi.KedroGraphQL
-KEDRO_GRAPHQL_BACKEND=kedro_graphql.backends.mongodb.MongoBackend
-KEDRO_GRAPHQL_BROKER=redis://localhost
-KEDRO_GRAPHQL_CELERY_RESULT_BACKEND=redis://localhost
-KEDRO_GRAPHQL_RUNNER=kedro.runner.SequentialRunner
-KEDRO_GRAPHQL_ENV=local
-KEDRO_GRAPHQL_CONF_SOURCE=None
-KEDRO_GRAPHQL_LOG_TMP_DIR=my_tmp_dir/
-KEDRO_GRAPHQL_LOG_PATH_PREFIX=s3://my-bucket/
-KEDRO_GRAPHQL_ROOT_PATH=/api/v1
-KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC=43200
-KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_SERVER_URL=http://localhost:5000
-KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_JWT_SECRET_KEY=your_secret_key
-KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_JWT_ALGORITHM=HS256
-KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS=/path/to/download
-KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_ALLOWED_ROOTS=/path/to/upload
-KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_MAX_FILE_SIZE_MB=10
+--app-title "My Custom App"
+--mongo-uri "mongodb://localhost:27017/"
 ```
 
-## Command line
+Numeric values are automatically converted:
 
-The configuration can also be provided at startup through the cli interface.
-Configuration values can be mapped to the the appropriate cli option by
-removing the "KEDRO_GRAPHQL_" prefix and using a lower case, hyphen format
-for the remaining string.  For example:
+```bash
+--signed-url-max-expires-in-sec 3600
+--local-file-provider-upload-max-file-size-mb 50
+```
 
-| configuration attribute      | cli option           | example                                   |
-|----------------------------|----------------------|-------------------------------------------|
-| mongo_uri                  | --mongo-uri          | mongodb://root:example@localhost:27017/   |
-| mongo_db_name              | --mongo-db-name      | pipelines                                 |
-| imports                    | --imports            | kedro_graphql.plugins.plugins             |
-| app                        | --app                | kedro_graphql.asgi.KedroGraphQL           |
-| backend                    | --backend            | kedro_graphql.backends.mongodb.MongoBackend|
-| broker                     | --broker             | redis://localhost                         |
-| celery_result_backend      | --celery-result-backend| redis://localhost                       |
-| runner                     | --runner             | kedro.runner.SequentialRunner             |
-| env                        | --env                | local                                     |
-| conf_source                | --conf-source        | $HOME/myproject/conf                      |
-| log_tmp_dir                | --log-tmp-dir        | my_tmp_dir/                               |
-| log_path_prefix            | --log-path-prefix    | s3://my-bucket/                           |
-| root_path                  | --root-path          | /api/v1                                   |
+List-type configuration options support multiple input formats:
 
+**Comma-separated strings:**
+
+```bash
+--imports "module1.plugin,module2.plugin,module3.plugin"
+--local-file-provider-download-allowed-roots "./data,/var,/tmp"
+```
+
+**JSON arrays:**
+
+```bash
+--imports '["module1.plugin", "module2.plugin"]'
+--local-file-provider-download-allowed-roots '["./data", "/var", "/tmp"]'
+```
+
+**Single values (automatically converted to list):**
+
+```bash
+--imports "single.module"
+--local-file-provider-upload-allowed-roots "./uploads"
+```
+
+Complex dictionary configurations must be provided as JSON strings:
+
+```bash
+--events-config '{"event1": {"source": "app", "type": "test"}}'
+--permissions-role-to-action-map '{"admin": ["create_pipeline", "read_pipeline"]}'
+```
+
+When using environment variables, list and dictionary values should be provided as:
+
+- **Lists**: Comma-separated strings or JSON arrays
+- **Dictionaries**: JSON strings
+
+```bash
+export KEDRO_GRAPHQL_IMPORTS="module1,module2,module3"
+export KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS='["./data", "/tmp"]'
+export KEDRO_GRAPHQL_EVENTS_CONFIG='{"event1": {"source": "app"}}'
+```
+
+## Configuration Precedence
+
+Configuration values are loaded with the following precedence order (highest to lowest):
+
+1. **YAML Spec** (highest precedence) - Values specified in the YAML spec file passed via `--api-spec` or `--ui-spec`
+2. **Command Line Flags** - Values passed as CLI arguments to the `kedro gql` command
+3. **Environment Variables** - Values set as environment variables with `KEDRO_GRAPHQL_` prefix
+4. **.env File** - Values defined in a `.env` file in the project root
+5. **Defaults** (lowest precedence) - Built-in default values
+
+This means that if the same configuration option is specified in multiple places, the source with higher precedence will override those with lower precedence. For example, a value in the YAML spec will override the same value specified via CLI flags, environment variables, or defaults.
 
 ## YAML API Specification
 
-The YAML API uses a snake case format without the `KEDRO_GRAPHQL_` prefix.
+The YAML API uses a snake case format without the `KEDRO_GRAPHQL_` prefix. In YAML specs, you can use native YAML data types (lists, dictionaries) directly.
+
+### Basic YAML Configuration Example
 
 ```yaml
 ## Kedro GraphQL YAML API configuration file.
 config:
-  mongo_uri: "mongodb://root:example@localhost:27017/"
-  mongo_db_name: "pipelines"
-  mongo_db_collection: "pipelines" 
-  imports:
-    - "kedro_graphql.plugins.plugins"
   app: "kedro_graphql.asgi.KedroGraphQL"
-  app_title: "Kedro GraphQL"
   app_description: "A tool for serving kedro projects as a GraphQL API"
-  project_version: "1.0.1"
+  app_title: "Kedro GraphQL"
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
-  runner: kedro.runner.SequentialRunner"
-  env: "local"
   conf_source: null
-  deprecation_docs: "https://github.com/opensean/kedro-graphql/blob/main/README.md#deprecations"
-  log_tmp_dir: "/tmp/"
-  log_path_prefix: null
-  root_path: null
+  deprecations_docs: ""
+  env: "local"
   events_config:
     event00:
       source: "example.com"
       type: "com.example.event"
+    event01:
+      source: "api.service.com"
+      type: "com.service.notification"
+  imports:
+    - "kedro_graphql.plugins.plugins"
+    - "custom.plugins"
+  local_file_provider_download_allowed_roots:
+    - "./data"
+    - "/var"
+    - "/tmp"
+  local_file_provider_jwt_algorithm: "HS256"
+  local_file_provider_jwt_secret_key: "my-secret-key"
+  local_file_provider_server_url: "http://localhost:5000"
+  local_file_provider_upload_allowed_roots:
+    - "./data"
+    - "./uploads"
+  local_file_provider_upload_max_file_size_mb: 10
+  log_path_prefix: null
+  log_tmp_dir: "/tmp/"
+  mongo_db_collection: "pipelines"
+  mongo_db_name: "pipelines"
+  mongo_uri: "mongodb://root:example@localhost:27017/"
   permissions: "kedro_graphql.permissions.IsAuthenticatedXForwardedEmail"
+  permissions_group_to_role_map: 
+    EXTERNAL_ADMIN_GROUP: admin
+    EXTERNAL_VIEWER_GROUP: viewer
   permissions_role_to_action_map:
     admin:
       - "create_pipeline"
@@ -141,16 +175,140 @@ config:
       - "subscribe_to_events"
       - "subscribe_to_logs"
       - "create_event"
-  permissions_group_to_role_map: 
-      EXTERNAL_GROUP_NAME: 
-          - admin
-
-
+    viewer:
+      - "read_pipeline"
+      - "read_pipelines"
+      - "read_dataset"
+  project_version: "1.0.1"
+  root_path: null
+  runner: "kedro.runner.SequentialRunner"
+  signed_url_max_expires_in_sec: 43200
+  signed_url_provider: "kedro_graphql.signed_url.s3_provider.S3Provider"
 ```
 
+### Using the API Spec
 
-Use the `--api-spec` flag to specify the path to the configuration file 
+Use the `--api-spec` flag to specify the path to the configuration file:
 
-```
+```bash
 kedro gql --api-spec spec-api.yaml
+```
+
+## Command line
+
+The configuration can also be provided at startup through the cli interface.
+Configuration values can be mapped to the the appropriate cli option by
+removing the `KEDRO_GRAPHQL_` prefix and using a lower case, hyphen format
+for the remaining string. For complex data types (lists, dictionaries),
+provide them as JSON strings.
+
+| configuration attribute                              | cli option                                       | example                                              |
+|----------------------------------------------------|--------------------------------------------------|------------------------------------------------------|
+| app                                                | --app                                            | kedro_graphql.asgi.KedroGraphQL                      |
+| app_title                                          | --app-title                                      | "My Custom Kedro GraphQL"                           |
+| app_description                                    | --app-description                                | "Custom description"                                 |
+| backend                                            | --backend                                        | kedro_graphql.backends.mongodb.MongoBackend         |
+| broker                                             | --broker                                         | redis://localhost                                    |
+| celery_result_backend                              | --celery-result-backend                          | redis://localhost                                    |
+| conf_source                                        | --conf-source                                    | $HOME/myproject/conf                                 |
+| deprecations_docs                                  | --deprecations-docs                              | `https://github.com/myrepo/docs` (optional)         |
+| env                                                | --env                                            | local                                                |
+| events_config                                      | --events-config                                  | '{"event1": {"source": "app", "type": "test"}}'     |
+| imports                                            | --imports                                        | `kedro_graphql.plugins.plugins` or `["module1", "module2"]` |
+| local_file_provider_download_allowed_roots         | --local-file-provider-download-allowed-roots    | `./data,/var,/tmp` or `["./data", "/var", "/tmp"]`   |
+| local_file_provider_jwt_algorithm                  | --local-file-provider-jwt-algorithm             | HS256                                                |
+| local_file_provider_jwt_secret_key                 | --local-file-provider-jwt-secret-key            | my-secret-key                                        |
+| local_file_provider_server_url                     | --local-file-provider-server-url                | `http://localhost:5000`                              |
+| local_file_provider_upload_allowed_roots           | --local-file-provider-upload-allowed-roots      | `./data` or `["./data"]`                             |
+| local_file_provider_upload_max_file_size_mb        | --local-file-provider-upload-max-file-size-mb   | 10                                                   |
+| log_path_prefix                                    | --log-path-prefix                                | s3://my-bucket/                                      |
+| log_tmp_dir                                        | --log-tmp-dir                                    | my_tmp_dir/                                          |
+| mongo_db_collection                                | --mongo-db-collection                            | pipelines                                            |
+| mongo_db_name                                      | --mongo-db-name                                  | pipelines                                            |
+| mongo_uri                                          | --mongo-uri                                      | mongodb://root:example@localhost:27017/              |
+| permissions                                        | --permissions                                    | kedro_graphql.permissions.IsAuthenticatedAlways     |
+| permissions_group_to_role_map                      | --permissions-group-to-role-map                 | '{"EXTERNAL_GROUP_NAME": "admin"}'                  |
+| permissions_role_to_action_map                     | --permissions-role-to-action-map                | '{"admin": ["create_pipeline", "read_pipeline"]}'    |
+| project_version                                    | --project-version                                | 1.0.0                                                |
+| root_path                                          | --root-path                                      | /api/v1                                              |
+| runner                                             | --runner                                         | kedro.runner.SequentialRunner                       |
+| signed_url_max_expires_in_sec                      | --signed-url-max-expires-in-sec                  | 43200                                                |
+| signed_url_provider                                | --signed-url-provider                            | kedro_graphql.signed_url.s3_provider.S3Provider     |
+
+**Note:** For complex data types (lists, dictionaries), provide values as JSON strings. The system will automatically parse these JSON strings into the appropriate data structures.
+
+### CLI Examples
+
+**Basic usage:**
+
+```bash
+kedro gql --app-title "My Custom App" --mongo-uri "mongodb://localhost:27017/"
+```
+
+**Using JSON for complex data types:**
+
+```bash
+kedro gql --permissions-role-to-action-map '{"admin": ["create_pipeline", "read_pipeline"]}' \
+          --local-file-provider-download-allowed-roots '["./data", "/var", "/tmp"]'
+```
+
+**Different ways to specify imports:**
+
+```bash
+# Comma-separated string
+kedro gql --imports "module1.plugin,module2.plugin,module3.plugin"
+
+# JSON array
+kedro gql --imports '["module1.plugin", "module2.plugin"]'
+
+# Single module (automatically converted to list)
+kedro gql --imports "single.module"
+```
+
+**Different ways to specify file paths:**
+
+```bash
+# Comma-separated strings for file paths
+kedro gql --local-file-provider-download-allowed-roots "./data,/var,/tmp" \
+          --local-file-provider-upload-allowed-roots "./uploads,./data"
+
+# JSON arrays for file paths
+kedro gql --local-file-provider-download-allowed-roots '["./data", "/var", "/tmp"]' \
+          --local-file-provider-upload-allowed-roots '["./uploads", "./data"]'
+
+# Single paths (automatically converted to list)
+kedro gql --local-file-provider-upload-allowed-roots "./uploads"
+```
+
+## Environment
+
+Environment variables will take precedence over values defined in a `.env` file. When using environment variables, the configuration attribute name should be uppercase and prefixed with `KEDRO_GRAPHQL_`.
+
+### Environment Variable Format Examples
+
+**String values:**
+
+```bash
+KEDRO_GRAPHQL_MONGO_URI=mongodb://root:example@localhost:27017/
+KEDRO_GRAPHQL_APP_TITLE="My Custom Kedro GraphQL"
+KEDRO_GRAPHQL_BACKEND=kedro_graphql.backends.mongodb.MongoBackend
+```
+
+**List values (multiple formats supported):**
+
+```bash
+# Comma-separated strings
+KEDRO_GRAPHQL_IMPORTS=kedro_graphql.plugins.plugins,custom.plugin
+KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS=./data,/var,/tmp
+
+# JSON arrays
+KEDRO_GRAPHQL_IMPORTS='["kedro_graphql.plugins.plugins", "custom.plugin"]'
+KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_ALLOWED_ROOTS='["./data", "./uploads"]'
+```
+
+**Dictionary values (JSON format required):**
+
+```bash
+KEDRO_GRAPHQL_EVENTS_CONFIG='{"event1": {"source": "app", "type": "test"}}'
+KEDRO_GRAPHQL_PERMISSIONS_ROLE_TO_ACTION_MAP='{"admin": ["create_pipeline", "read_pipeline"]}'
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,7 +76,7 @@ source venv/bin/activate
 Install dependencies.
 
 ```bash
-pip install -r src/requirements.txt
+pip install .
 ```
 
 Create a text file.

--- a/spec-api-auth.yaml
+++ b/spec-api-auth.yaml
@@ -1,29 +1,29 @@
 ## Kedro GraphQL YAML API configuration file.
 config:
-  mongo_uri: "mongodb://root:example@localhost:27017/"
-  mongo_db_name: "pipelines"
-  mongo_db_collection: "pipelines" 
-  imports:
-    - "kedro_graphql.plugins.plugins"
   app: "kedro_graphql.asgi.KedroGraphQL"
-  app_title: "Kedro GraphQL"
   app_description: "A tool for serving kedro projects as a GraphQL API"
-  project_version: "1.0.1"
+  app_title: "Kedro GraphQL"
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
-  runner: "kedro.runner.SequentialRunner"
-  env: "local"
   conf_source: null
-  deprecation_docs: "https://github.com/opensean/kedro-graphql/blob/main/README.md#deprecations"
-  log_tmp_dir: "/tmp/"
-  log_path_prefix: null
-  root_path: null
+  deprecation_docs: ""
+  env: "local"
   events_config:
     event00:
       source: "example.com"
       type: "com.example.event"
+  imports:
+    - "kedro_graphql.plugins.plugins"
+  local_file_provider_server_url: "http://localhost:4180"
+  log_path_prefix: null
+  log_tmp_dir: "/tmp/"
+  mongo_db_collection: "pipelines"
+  mongo_db_name: "pipelines"
+  mongo_uri: "mongodb://root:example@localhost:27017/"
   permissions: "kedro_graphql.permissions.IsAuthenticatedXForwardedEmail"
+  permissions_group_to_role_map: 
+    EXTERNAL_GROUP_NAME: admin
   permissions_role_to_action_map:
     admin:
       - "create_pipeline"
@@ -38,8 +38,8 @@ config:
       - "subscribe_to_events"
       - "subscribe_to_logs"
       - "create_event"
-  permissions_group_to_role_map: 
-    EXTERNAL_GROUP_NAME: admin
-  local_file_provider_server_url: "http://localhost:4180"
+  project_version: "1.0.1"
+  root_path: null
+  runner: "kedro.runner.SequentialRunner"
 
 

--- a/spec-api-auth.yaml
+++ b/spec-api-auth.yaml
@@ -12,12 +12,13 @@ config:
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
-  runner: kedro.runner.SequentialRunner"
+  runner: "kedro.runner.SequentialRunner"
   env: "local"
   conf_source: null
   deprecation_docs: "https://github.com/opensean/kedro-graphql/blob/main/README.md#deprecations"
   log_tmp_dir: "/tmp/"
   log_path_prefix: null
+  root_path: null
   events_config:
     event00:
       source: "example.com"
@@ -38,8 +39,7 @@ config:
       - "subscribe_to_logs"
       - "create_event"
   permissions_group_to_role_map: 
-      EXTERNAL_GROUP_NAME: 
-          - admin
+    EXTERNAL_GROUP_NAME: admin
   local_file_provider_server_url: "http://localhost:4180"
 
 

--- a/spec-api.yaml
+++ b/spec-api.yaml
@@ -12,18 +12,19 @@ config:
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
-  runner: kedro.runner.SequentialRunner"
+  runner: "kedro.runner.SequentialRunner"
   env: "local"
   conf_source: null
   deprecation_docs: "https://github.com/opensean/kedro-graphql/blob/main/README.md#deprecations"
   log_tmp_dir: "/tmp/"
   log_path_prefix: null
+  root_path: null
   events_config:
     event00:
       source: "example.com"
       type: "com.example.event"
   permissions: "kedro_graphql.permissions.IsAuthenticatedAlways"
-  permissions_role_to_action_mapping:
+  permissions_role_to_action_map:
     admin:
       - "create_pipeline"
       - "read_pipeline"
@@ -37,9 +38,8 @@ config:
       - "subscribe_to_events"
       - "subscribe_to_logs"
       - "create_event"
-  permissions_group_to_role_mapping: 
-      EXTERNAL_GROUP_NAME: 
-          - admin
+  permissions_group_to_role_map: 
+    EXTERNAL_GROUP_NAME: admin
   local_file_provider_server_url: "http://localhost:5000"
 
 

--- a/spec-api.yaml
+++ b/spec-api.yaml
@@ -1,29 +1,29 @@
 ## Kedro GraphQL YAML API configuration file.
 config:
-  mongo_uri: "mongodb://root:example@localhost:27017/"
-  mongo_db_name: "pipelines"
-  mongo_db_collection: "pipelines" 
-  imports:
-    - "kedro_graphql.plugins.plugins"
   app: "kedro_graphql.asgi.KedroGraphQL"
-  app_title: "Kedro GraphQL"
   app_description: "A tool for serving kedro projects as a GraphQL API"
-  project_version: "1.0.1"
+  app_title: "Kedro GraphQL"
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
-  runner: "kedro.runner.SequentialRunner"
-  env: "local"
   conf_source: null
-  deprecation_docs: "https://github.com/opensean/kedro-graphql/blob/main/README.md#deprecations"
-  log_tmp_dir: "/tmp/"
-  log_path_prefix: null
-  root_path: null
+  deprecation_docs: ""
+  env: "local"
   events_config:
     event00:
       source: "example.com"
       type: "com.example.event"
+  imports:
+    - "kedro_graphql.plugins.plugins"
+  local_file_provider_server_url: "http://localhost:5000"
+  log_path_prefix: null
+  log_tmp_dir: "/tmp/"
+  mongo_db_collection: "pipelines"
+  mongo_db_name: "pipelines"
+  mongo_uri: "mongodb://root:example@localhost:27017/"
   permissions: "kedro_graphql.permissions.IsAuthenticatedAlways"
+  permissions_group_to_role_map: 
+    EXTERNAL_GROUP_NAME: admin
   permissions_role_to_action_map:
     admin:
       - "create_pipeline"
@@ -38,8 +38,8 @@ config:
       - "subscribe_to_events"
       - "subscribe_to_logs"
       - "create_event"
-  permissions_group_to_role_map: 
-    EXTERNAL_GROUP_NAME: admin
-  local_file_provider_server_url: "http://localhost:5000"
+  project_version: "1.0.1"
+  root_path: null
+  runner: "kedro.runner.SequentialRunner"
 
 

--- a/spec-ui-auth.yaml
+++ b/spec-ui-auth.yaml
@@ -1,21 +1,31 @@
 ## Kedro GraphQL UI configuration file
 # This file defines the structure and components of the Kedro GraphQL UI.
-panel_get_server_kwargs:  ## pass argument to the https://panel.holoviz.org/api/panel.io.server.html#panel.io.server.get_server function
-  title: Kedro GraphQL UI
-  show: false
-  admin: true
-  prefix: /
-  port: 5006
-  websocket_origin: 
-    - "localhost:5006"
-    - "localhost:4180"
-  warm: true
 config:
   client_uri_graphql: "http://localhost:4180/graphql"
   client_uri_ws: "ws://localhost:4180/graphql"
   imports:
     - "kedro_graphql.ui.plugins"
+nav:
+  sidebar:
+    - name: Pipelines
+      page: pipelines
+    - name: Search 
+      page: search
 pages:
+  dashboard:
+    module: kedro_graphql.ui.components.pipeline_dashboard_factory.PipelineDashboardFactory
+    params:
+      dataset_map:
+        pandas.CSVDataset: dataset_perspective
+        pandas.ParquetDataset: dataset_perspective
+  dataset_perspective:
+    module: kedro_graphql.ui.components.dataset_perspective.DatasetPerspective
+    params:
+      file_size_limit_mb: 10
+  explore:
+    module: kedro_graphql.ui.components.pipeline_viz.PipelineViz
+  form:
+    module: kedro_graphql.ui.components.pipeline_form_factory.PipelineFormFactory
   pipelines:
     module: kedro_graphql.ui.components.pipeline_cards.PipelineCards
     params:
@@ -25,23 +35,13 @@ pages:
     module: kedro_graphql.ui.components.pipeline_search.PipelineSearch
     params:
       dashboard_page: dashboard
-  dashboard:
-    module: kedro_graphql.ui.components.pipeline_dashboard_factory.PipelineDashboardFactory
-    params:
-      dataset_map:
-        pandas.CSVDataset: dataset_perspective
-        pandas.ParquetDataset: dataset_perspective
-  form:
-    module: kedro_graphql.ui.components.pipeline_form_factory.PipelineFormFactory
-  explore:
-    module: kedro_graphql.ui.components.pipeline_viz.PipelineViz
-  dataset_perspective:
-    module: kedro_graphql.ui.components.dataset_perspective.DatasetPerspective
-    params:
-      file_size_limit_mb: 10
-nav:
-  sidebar:
-    - name: Pipelines
-      page: pipelines
-    - name: Search 
-      page: search
+panel_get_server_kwargs:  ## pass argument to the https://panel.holoviz.org/api/panel.io.server.html#panel.io.server.get_server function
+  admin: true
+  port: 5006
+  prefix: /
+  show: false
+  title: Kedro GraphQL UI
+  warm: true
+  websocket_origin: 
+    - "localhost:5006"
+    - "localhost:4180"

--- a/spec-ui-auth.yaml
+++ b/spec-ui-auth.yaml
@@ -4,9 +4,9 @@ panel_get_server_kwargs:  ## pass argument to the https://panel.holoviz.org/api/
   title: Kedro GraphQL UI
   show: false
   admin: true
-  base_url: /
+  prefix: /
   port: 5006
-  allow_websocket_origin: 
+  websocket_origin: 
     - "localhost:5006"
     - "localhost:4180"
   warm: true

--- a/spec-ui.yaml
+++ b/spec-ui.yaml
@@ -1,20 +1,31 @@
 ## Kedro GraphQL UI configuration file
 # This file defines the structure and components of the Kedro GraphQL UI.
-panel_get_server_kwargs:  ## pass argument to the https://panel.holoviz.org/api/panel.io.server.html#panel.io.server.get_server function
-  title: Kedro GraphQL UI
-  show: false
-  admin: true
-  prefix: /
-  port: 5006
-  websocket_origin: 
-    - "localhost:5006"
-  warm: true
 config:
   client_uri_graphql: "http://localhost:5000/graphql"
   client_uri_ws: "ws://localhost:5000/graphql"
   imports:
     - "kedro_graphql.ui.plugins"
+nav:
+  sidebar:
+    - name: Pipelines
+      page: pipelines
+    - name: Search 
+      page: search
 pages:
+  dashboard:
+    module: kedro_graphql.ui.components.pipeline_dashboard_factory.PipelineDashboardFactory
+    params:
+      dataset_map:
+        pandas.CSVDataset: dataset_perspective
+        pandas.ParquetDataset: dataset_perspective
+  dataset_perspective:
+    module: kedro_graphql.ui.components.dataset_perspective.DatasetPerspective
+    params:
+      file_size_limit_mb: 10
+  explore:
+    module: kedro_graphql.ui.components.pipeline_viz.PipelineViz
+  form:
+    module: kedro_graphql.ui.components.pipeline_form_factory.PipelineFormFactory
   pipelines:
     module: kedro_graphql.ui.components.pipeline_cards.PipelineCards
     params:
@@ -24,23 +35,12 @@ pages:
     module: kedro_graphql.ui.components.pipeline_search.PipelineSearch
     params:
       dashboard_page: dashboard
-  dashboard:
-    module: kedro_graphql.ui.components.pipeline_dashboard_factory.PipelineDashboardFactory
-    params:
-      dataset_map:
-        pandas.CSVDataset: dataset_perspective
-        pandas.ParquetDataset: dataset_perspective
-  form:
-    module: kedro_graphql.ui.components.pipeline_form_factory.PipelineFormFactory
-  explore:
-    module: kedro_graphql.ui.components.pipeline_viz.PipelineViz
-  dataset_perspective:
-    module: kedro_graphql.ui.components.dataset_perspective.DatasetPerspective
-    params:
-      file_size_limit_mb: 10
-nav:
-  sidebar:
-    - name: Pipelines
-      page: pipelines
-    - name: Search 
-      page: search
+panel_get_server_kwargs:  ## pass argument to the https://panel.holoviz.org/api/panel.io.server.html#panel.io.server.get_server function
+  admin: true
+  port: 5006
+  prefix: /
+  show: false
+  title: Kedro GraphQL UI
+  warm: true
+  websocket_origin: 
+    - "localhost:5006"

--- a/spec-ui.yaml
+++ b/spec-ui.yaml
@@ -4,9 +4,9 @@ panel_get_server_kwargs:  ## pass argument to the https://panel.holoviz.org/api/
   title: Kedro GraphQL UI
   show: false
   admin: true
-  base_url: /
+  prefix: /
   port: 5006
-  allow_websocket_origin: 
+  websocket_origin: 
     - "localhost:5006"
   warm: true
 config:

--- a/src/kedro_graphql/asgi.py
+++ b/src/kedro_graphql/asgi.py
@@ -31,6 +31,7 @@ class KedroGraphQL(FastAPI):
             description=config["KEDRO_GRAPHQL_APP_DESCRIPTION"],
             version=config["KEDRO_GRAPHQL_PROJECT_VERSION"],
             docs_url="/docs",  # Swagger UI URL
+            root_path=config["KEDRO_GRAPHQL_ROOT_PATH"],
         )
 
         self.kedro_session = kedro_session

--- a/src/kedro_graphql/commands.py
+++ b/src/kedro_graphql/commands.py
@@ -51,28 +51,28 @@ def commands():
 )
 @click.option(
     "--backend",
-    default=defaults["KEDRO_GRAPHQL_BACKEND"],
+    default=None,
     help="The only supported value for this option is 'kedro_graphql.backends.mongodb.MongoBackend'"
 )
 @click.option(
     "--broker",
-    default=defaults["KEDRO_GRAPHQL_BROKER"],
+    default=None,
     help="URI to broker e.g. 'redis://localhost'"
 )
 @click.option(
     "--celery-result-backend",
-    default=defaults["KEDRO_GRAPHQL_CELERY_RESULT_BACKEND"],
+    default=None,
     help="URI to backend for celery results e.g. 'redis://localhost'"
 )
 @click.option(
     "--conf-source",
-    default=defaults["KEDRO_GRAPHQL_CONF_SOURCE"],
+    default=None,
     help="Path of a directory where project configuration is stored."
 )
 @click.option(
     "--env",
     "-e",
-    default=defaults["KEDRO_GRAPHQL_ENV"],
+    default=None,
     help="Kedro configuration environment name. Defaults to `local`."
 )
 @click.option(
@@ -83,28 +83,33 @@ def commands():
 )
 @click.option(
     "--mongo-uri",
-    default=defaults["KEDRO_GRAPHQL_MONGO_URI"],
+    default=None,
     help="URI to mongodb e.g. 'mongodb://root:example@localhost:27017/'"
 )
 @click.option(
     "--mongo-db-name",
-    default=defaults["KEDRO_GRAPHQL_MONGO_DB_NAME"],
+    default=None,
     help="Name to use for collection in mongo e.g. 'pipelines'"
 )
 @click.option(
     "--runner",
-    default=defaults["KEDRO_GRAPHQL_RUNNER"],
+    default=None,
     help="Execution mechanism to run pipelines e.g. 'kedro.runner.SequentialRunner'"
 )
 @click.option(
     "--log-tmp-dir",
-    default=defaults["KEDRO_GRAPHQL_LOG_TMP_DIR"],
+    default=None,
     help="Temporary directory for logs"
 )
 @click.option(
     "--log-path-prefix",
-    default=defaults["KEDRO_GRAPHQL_LOG_PATH_PREFIX"],
+    default=None,
     help="Prefix of path to save logs"
+)
+@click.option(
+    "--root-path",
+    default=None,
+    help="Root path for API endpoints (e.g., '/api/v1')"
 )
 @click.option(
     "--reload",
@@ -146,7 +151,7 @@ def commands():
 )
 def gql(metadata, app, backend, broker, celery_result_backend, conf_source,
         env, imports, mongo_uri, mongo_db_name, runner, log_tmp_dir,
-        log_path_prefix, reload, reload_path, api_spec, ui, ui_spec,
+        log_path_prefix, root_path, reload, reload_path, api_spec, ui, ui_spec,
         worker):
     """Commands for working with kedro-graphql."""
 
@@ -176,6 +181,8 @@ def gql(metadata, app, backend, broker, celery_result_backend, conf_source,
         os.environ["KEDRO_GRAPHQL_LOG_TMP_DIR"] = log_tmp_dir
     if log_path_prefix:
         os.environ["KEDRO_GRAPHQL_LOG_PATH_PREFIX"] = log_path_prefix
+    if root_path:
+        os.environ["KEDRO_GRAPHQL_ROOT_PATH"] = root_path
 
     os.environ["KEDRO_GRAPHQL_PROJECT_VERSION"] = getattr(
         import_module(metadata.package_name), "__version__", None)

--- a/src/kedro_graphql/commands.py
+++ b/src/kedro_graphql/commands.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import json
 from importlib import import_module
 
 import click
@@ -43,152 +44,122 @@ def commands():
 
 @commands.command()
 @click.pass_obj
-@click.option(
-    "--app",
-    "-a",
-    default=None,
-    help="Application import path"
-)
-@click.option(
-    "--backend",
-    default=None,
-    help="The only supported value for this option is 'kedro_graphql.backends.mongodb.MongoBackend'"
-)
-@click.option(
-    "--broker",
-    default=None,
-    help="URI to broker e.g. 'redis://localhost'"
-)
-@click.option(
-    "--celery-result-backend",
-    default=None,
-    help="URI to backend for celery results e.g. 'redis://localhost'"
-)
-@click.option(
-    "--conf-source",
-    default=None,
-    help="Path of a directory where project configuration is stored."
-)
-@click.option(
-    "--env",
-    "-e",
-    default=None,
-    help="Kedro configuration environment name. Defaults to `local`."
-)
-@click.option(
-    "--imports",
-    "-i",
-    default=None,
-    help="Additional import paths"
-)
-@click.option(
-    "--mongo-uri",
-    default=None,
-    help="URI to mongodb e.g. 'mongodb://root:example@localhost:27017/'"
-)
-@click.option(
-    "--mongo-db-name",
-    default=None,
-    help="Name to use for collection in mongo e.g. 'pipelines'"
-)
-@click.option(
-    "--runner",
-    default=None,
-    help="Execution mechanism to run pipelines e.g. 'kedro.runner.SequentialRunner'"
-)
-@click.option(
-    "--log-tmp-dir",
-    default=None,
-    help="Temporary directory for logs"
-)
-@click.option(
-    "--log-path-prefix",
-    default=None,
-    help="Prefix of path to save logs"
-)
-@click.option(
-    "--root-path",
-    default=None,
-    help="Root path for API endpoints (e.g., '/api/v1')"
-)
-@click.option(
-    "--reload",
-    "-r",
-    is_flag=True,
-    default=False,
-    help="Enable auto-reload."
-)
-@click.option(
-    "--reload-path",
-    default=None,
-    type=click.Path(exists=True, resolve_path=True, path_type=pathlib.Path),
-    help="Path to watch for file changes, defaults to <project path>/src"
-)
-@click.option(
-    "--api-spec",
-    default=None,
-    type=click.Path(exists=True, resolve_path=True, path_type=pathlib.Path),
-    help="Path to watch for file changes, defaults to <project path>/src"
-)
-@click.option(
-    "--ui",
-    "-u",
-    is_flag=True,
-    default=False,
-    help="Start a viz app."
-)
-@click.option(
-    "--ui-spec",
-    default="",
-    help="UI YAML specification file"
-)
-@click.option(
-    "--worker",
-    "-w",
-    is_flag=True,
-    default=False,
-    help="Start a celery worker."
-)
-def gql(metadata, app, backend, broker, celery_result_backend, conf_source,
-        env, imports, mongo_uri, mongo_db_name, runner, log_tmp_dir,
-        log_path_prefix, root_path, reload, reload_path, api_spec, ui, ui_spec,
-        worker):
+@click.option("--app", "-a", default=None, help="Application import path")
+@click.option("--app-title", default=None, help="Title of the Kedro GraphQL application")
+@click.option("--app-description", default=None, help="Description of the Kedro GraphQL application")
+@click.option("--backend", default=None, help="The only supported value for this option is 'kedro_graphql.backends.mongodb.MongoBackend'")
+@click.option("--broker", default=None, help="URI to broker e.g. 'redis://localhost'")
+@click.option("--celery-result-backend", default=None, help="URI to backend for celery results e.g. 'redis://localhost'")
+@click.option("--conf-source", default=None, help="Path of a directory where project configuration is stored.")
+@click.option("--deprecations-docs", default=None, help="URL to documentation about deprecated features")
+@click.option("--env", "-e", default=None, help="Kedro configuration environment name. Defaults to `local`.")
+@click.option("--events-config", default=None, help="Event configuration as JSON string")
+@click.option("--imports", "-i", default=None, help="Additional import paths (comma-separated string or JSON array)")
+@click.option("--local-file-provider-download-allowed-roots", default=None, help="Allowed root directories for downloads (comma-separated string or JSON array)")
+@click.option("--local-file-provider-jwt-algorithm", default=None, help="Algorithm used for JWT signing (e.g., 'HS256')")
+@click.option("--local-file-provider-jwt-secret-key", default=None, help="Secret key for signing JWT tokens for local file access")
+@click.option("--local-file-provider-server-url", default=None, help="Base URL for the local file server")
+@click.option("--local-file-provider-upload-allowed-roots", default=None, help="Allowed root directories for uploads (comma-separated string or JSON array)")
+@click.option("--local-file-provider-upload-max-file-size-mb", default=None, type=int, help="Maximum allowed upload file size in megabytes")
+@click.option("--log-path-prefix", default=None, help="Prefix of path to save logs")
+@click.option("--log-tmp-dir", default=None, help="Temporary directory for logs")
+@click.option("--mongo-db-collection", default=None, help="Name of the MongoDB collection to use")
+@click.option("--mongo-db-name", default=None, help="Name to use for collection in mongo e.g. 'pipelines'")
+@click.option("--mongo-uri", default=None, help="URI to mongodb e.g. 'mongodb://root:example@localhost:27017/'")
+@click.option("--permissions", default=None, help="Python path to the permissions class used for authentication")
+@click.option("--permissions-group-to-role-map", default=None, help="Mapping of external group names to roles as JSON string")
+@click.option("--permissions-role-to-action-map", default=None, help="Mapping of roles to allowed actions as JSON string")
+@click.option("--project-version", default=None, help="Version of the Kedro GraphQL project")
+@click.option("--root-path", default=None, help="Root path for API endpoints (e.g., '/api/v1')")
+@click.option("--runner", default=None, help="Execution mechanism to run pipelines e.g. 'kedro.runner.SequentialRunner'")
+@click.option("--signed-url-max-expires-in-sec", default=None, type=int, help="Maximum allowed expiration time (in seconds) for presigned URLs")
+@click.option("--signed-url-provider", default=None, help="Python path to the presigned URL provider class")
+@click.option("--reload", "-r", is_flag=True, default=False, help="Enable auto-reload.")
+@click.option("--reload-path", default=None, type=click.Path(exists=True, resolve_path=True, path_type=pathlib.Path), help="Path to watch for file changes, defaults to <project path>/src")
+@click.option("--api-spec", default=None, type=click.Path(exists=True, resolve_path=True, path_type=pathlib.Path), help="Path to YAML API specification file")
+@click.option("--ui", "-u", is_flag=True, default=False, help="Start a viz app.")
+@click.option("--ui-spec", default="", help="UI YAML specification file")
+@click.option("--worker", "-w", is_flag=True, default=False, help="Start a celery worker.")
+def gql(metadata, app, app_title, app_description, backend, broker, celery_result_backend, conf_source,
+        deprecations_docs, env, events_config, imports, local_file_provider_download_allowed_roots,
+        local_file_provider_jwt_algorithm, local_file_provider_jwt_secret_key, local_file_provider_server_url,
+        local_file_provider_upload_allowed_roots, local_file_provider_upload_max_file_size_mb,
+        log_path_prefix, log_tmp_dir, mongo_db_collection, mongo_db_name, mongo_uri, permissions,
+        permissions_group_to_role_map, permissions_role_to_action_map, project_version, root_path, runner,
+        signed_url_max_expires_in_sec, signed_url_provider, reload, reload_path, api_spec, ui, ui_spec, worker):
     """Commands for working with kedro-graphql."""
 
+    # Collect CLI configuration instead of setting as environment variables
+    cli_config = {}
+    
     if api_spec:
         os.environ["KEDRO_GRAPHQL_API_SPEC"] = str(api_spec)
-    if mongo_uri:
-        os.environ["KEDRO_GRAPHQL_MONGO_URI"] = mongo_uri
-    if mongo_db_name:
-        os.environ["KEDRO_GRAPHQL_MONGO_DB_NAME"] = mongo_db_name
-    if imports:
-        os.environ["KEDRO_GRAPHQL_IMPORTS"] = imports
     if app:
-        os.environ["KEDRO_GRAPHQL_APP"] = app
+        cli_config["KEDRO_GRAPHQL_APP"] = app
+    if app_title:
+        cli_config["KEDRO_GRAPHQL_APP_TITLE"] = app_title
+    if app_description:
+        cli_config["KEDRO_GRAPHQL_APP_DESCRIPTION"] = app_description
     if backend:
-        os.environ["KEDRO_GRAPHQL_BACKEND"] = backend
+        cli_config["KEDRO_GRAPHQL_BACKEND"] = backend
     if broker:
-        os.environ["KEDRO_GRAPHQL_BROKER"] = broker
+        cli_config["KEDRO_GRAPHQL_BROKER"] = broker
     if celery_result_backend:
-        os.environ["KEDRO_GRAPHQL_CELERY_RESULT_BACKEND"] = celery_result_backend
+        cli_config["KEDRO_GRAPHQL_CELERY_RESULT_BACKEND"] = celery_result_backend
     if conf_source:
-        os.environ["KEDRO_GRAPHQL_CONF_SOURCE"] = conf_source
+        cli_config["KEDRO_GRAPHQL_CONF_SOURCE"] = conf_source
+    if deprecations_docs:
+        cli_config["KEDRO_GRAPHQL_DEPRECATIONS_DOCS"] = deprecations_docs
     if env:
-        os.environ["KEDRO_GRAPHQL_ENV"] = env
-    if runner:
-        os.environ["KEDRO_GRAPHQL_RUNNER"] = runner
-    if log_tmp_dir:
-        os.environ["KEDRO_GRAPHQL_LOG_TMP_DIR"] = log_tmp_dir
+        cli_config["KEDRO_GRAPHQL_ENV"] = env
+    if events_config:
+        cli_config["KEDRO_GRAPHQL_EVENTS_CONFIG"] = events_config
+    if imports:
+        cli_config["KEDRO_GRAPHQL_IMPORTS"] = imports
+    if local_file_provider_download_allowed_roots:
+        cli_config["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS"] = local_file_provider_download_allowed_roots
+    if local_file_provider_jwt_algorithm:
+        cli_config["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_JWT_ALGORITHM"] = local_file_provider_jwt_algorithm
+    if local_file_provider_jwt_secret_key:
+        cli_config["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_JWT_SECRET_KEY"] = local_file_provider_jwt_secret_key
+    if local_file_provider_server_url:
+        cli_config["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_SERVER_URL"] = local_file_provider_server_url
+    if local_file_provider_upload_allowed_roots:
+        cli_config["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_ALLOWED_ROOTS"] = local_file_provider_upload_allowed_roots
+    if local_file_provider_upload_max_file_size_mb is not None:
+        cli_config["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_MAX_FILE_SIZE_MB"] = local_file_provider_upload_max_file_size_mb
     if log_path_prefix:
-        os.environ["KEDRO_GRAPHQL_LOG_PATH_PREFIX"] = log_path_prefix
+        cli_config["KEDRO_GRAPHQL_LOG_PATH_PREFIX"] = log_path_prefix
+    if log_tmp_dir:
+        cli_config["KEDRO_GRAPHQL_LOG_TMP_DIR"] = log_tmp_dir
+    if mongo_db_collection:
+        cli_config["KEDRO_GRAPHQL_MONGO_DB_COLLECTION"] = mongo_db_collection
+    if mongo_db_name:
+        cli_config["KEDRO_GRAPHQL_MONGO_DB_NAME"] = mongo_db_name
+    if mongo_uri:
+        cli_config["KEDRO_GRAPHQL_MONGO_URI"] = mongo_uri
+    if permissions:
+        cli_config["KEDRO_GRAPHQL_PERMISSIONS"] = permissions
+    if permissions_group_to_role_map:
+        cli_config["KEDRO_GRAPHQL_PERMISSIONS_GROUP_TO_ROLE_MAP"] = permissions_group_to_role_map
+    if permissions_role_to_action_map:
+        cli_config["KEDRO_GRAPHQL_PERMISSIONS_ROLE_TO_ACTION_MAP"] = permissions_role_to_action_map
+    if project_version:
+        cli_config["KEDRO_GRAPHQL_PROJECT_VERSION"] = project_version
     if root_path:
-        os.environ["KEDRO_GRAPHQL_ROOT_PATH"] = root_path
+        cli_config["KEDRO_GRAPHQL_ROOT_PATH"] = root_path
+    if runner:
+        cli_config["KEDRO_GRAPHQL_RUNNER"] = runner
+    if signed_url_max_expires_in_sec is not None:
+        cli_config["KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC"] = signed_url_max_expires_in_sec
+    if signed_url_provider:
+        cli_config["KEDRO_GRAPHQL_SIGNED_URL_PROVIDER"] = signed_url_provider
 
     os.environ["KEDRO_GRAPHQL_PROJECT_VERSION"] = getattr(
         import_module(metadata.package_name), "__version__", None)
     os.environ["KEDRO_PROJECT_NAME"] = metadata.package_name
 
-    config = load_config()
+    config = load_config(cli_config=cli_config)
     logger.debug("configuration loaded by {s}".format(s=__name__))
 
     if not reload_path:

--- a/src/kedro_graphql/config.py
+++ b/src/kedro_graphql/config.py
@@ -70,6 +70,7 @@ def load_api_spec():
                 conf = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 logger.error(str(exc))
+                return {}
 
         # import additinal modules to enable plugin discovery
         # e.g. @gql_form, @gql_data, etc...
@@ -153,6 +154,4 @@ def load_config(cli_config=None):
         **load_api_spec(),  # YAML API spec (highest precedence)
     }
     config = env_var_parser(config)  # special parsing for any environment variables
-
-    print(f"Kedro app description: {config.get('KEDRO_GRAPHQL_APP_DESCRIPTION', 'N/A')}")
     return config

--- a/src/kedro_graphql/config.py
+++ b/src/kedro_graphql/config.py
@@ -28,6 +28,7 @@ defaults = {
     "KEDRO_GRAPHQL_DEPRECATIONS_DOCS": "https://github.com/opensean/kedro-graphql/blob/main/README.md#deprecations",
     "KEDRO_GRAPHQL_LOG_TMP_DIR": tempfile.TemporaryDirectory().name,
     "KEDRO_GRAPHQL_LOG_PATH_PREFIX": None,
+    "KEDRO_GRAPHQL_ROOT_PATH": "",
     "KEDRO_GRAPHQL_SIGNED_URL_PROVIDER": "kedro_graphql.signed_url.s3_provider.S3Provider",
     "KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC": 43200,
     "KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_SERVER_URL": "http://localhost:5000",
@@ -114,8 +115,8 @@ def load_config():
     config = {
         **copy.deepcopy(defaults),  # defaults
         **dotenv_values(".env"),  # .env file
-        **load_api_spec(),  # loaded API spec
         **os.environ,  # override loaded values with environment variables
+        **load_api_spec(),  # loaded API spec
     }
     config = env_var_parser(config)  # special parsing for any environment variables
     return config

--- a/src/kedro_graphql/decorators.py
+++ b/src/kedro_graphql/decorators.py
@@ -11,7 +11,16 @@ TYPE_PLUGINS = {"query": [],
 
 def discover_plugins(config):
     # discover plugins e.g. decorated functions e.g @gql_query, etc...
-    imports = [i.strip() for i in config["KEDRO_GRAPHQL_IMPORTS"].split(",") if len(i.strip()) > 0]
+    kedro_imports = config["KEDRO_GRAPHQL_IMPORTS"]
+    
+    # Handle both string and list types
+    if isinstance(kedro_imports, str):
+        imports = [i.strip() for i in kedro_imports.split(",") if len(i.strip()) > 0]
+    elif isinstance(kedro_imports, list):
+        imports = [i.strip() for i in kedro_imports if len(i.strip()) > 0]
+    else:
+        imports = []
+    
     for i in imports:
         import_module(i)
 

--- a/src/kedro_graphql/decorators.py
+++ b/src/kedro_graphql/decorators.py
@@ -11,17 +11,7 @@ TYPE_PLUGINS = {"query": [],
 
 def discover_plugins(config):
     # discover plugins e.g. decorated functions e.g @gql_query, etc...
-    kedro_imports = config["KEDRO_GRAPHQL_IMPORTS"]
-    
-    # Handle both string and list types
-    if isinstance(kedro_imports, str):
-        imports = [i.strip() for i in kedro_imports.split(",") if len(i.strip()) > 0]
-    elif isinstance(kedro_imports, list):
-        imports = [i.strip() for i in kedro_imports if len(i.strip()) > 0]
-    else:
-        imports = []
-    
-    for i in imports:
+    for i in config["KEDRO_GRAPHQL_IMPORTS"]:
         import_module(i)
 
 

--- a/src/kedro_graphql/signed_url/s3_provider.py
+++ b/src/kedro_graphql/signed_url/s3_provider.py
@@ -61,7 +61,7 @@ class S3Provider(SignedUrlProvider):
                 s3_client = boto3.client('s3')
                 params = {
                     'Bucket': bucket_name,
-                    'Key': f"{key}/{filename}"
+                    'Key': f"{key}/{filename}" if key else filename
                 }
 
                 try:

--- a/src/kedro_graphql/ui/components/data_catalog_explorer.py
+++ b/src/kedro_graphql/ui/components/data_catalog_explorer.py
@@ -1,35 +1,66 @@
-import panel as pn
-import param
-import pandas as pd
+import asyncio
 import json
-
+import param
+import panel as pn
+import pandas as pd
 from kedro_graphql.models import Pipeline
 
 pn.extension(notifications=True)
 
-
 class DataCatalogExplorer(pn.viewable.Viewer):
-    """A component that displays the data catalog of a Kedro pipeline, allowing users to filter, view,
-    and download datasets using their pre-signed URL implementation of choice."""
+    """
+    A Panel component that displays the data catalog of a Kedro pipeline, allowing users to filter, view,
+    and download datasets using their pre-signed URL implementation of choice.
 
-    pipeline = param.ClassSelector(class_=Pipeline)
-    spec = param.Dict(default={})
-    dataset_map = param.Dict(default={})
+    Attributes:
+        pipeline (kedro_graphql.models.Pipeline): The Kedro pipeline object
+        spec (dict): Kedro GraphQL UI specification
+        dataset_map (dict): A mapping of Kedro dataset types to their corresponding rendering Panel components
+    """
+
+    pipeline = param.ClassSelector(class_=Pipeline, doc="The Kedro pipeline object")
+    spec = param.Dict(default={}, doc="Kedro GraphQL UI specification")
+    dataset_map = param.Dict(default={}, doc="A mapping of Kedro dataset types to their corresponding rendering Panel components")
 
     def __init__(self, **params):
         super().__init__(**params)
 
-    @param.depends("pipeline", "spec", "dataset_map")
-    async def build_component(self):
-        yield pn.indicators.LoadingSpinner(value=True, width=25, height=25)
+        # this is used to inject JS dynamically
+        self.js_download = pn.pane.HTML("", width=0, height=0)
 
+        if not self.pipeline or not self.spec:
+            self._content = pn.Column(
+                pn.pane.Markdown("**Missing required parameters: `pipeline`, or `spec`.**"),
+                sizing_mode="stretch_width"
+            )
+        else:
+            # Show loading spinner until the dashboard is built
+            self._content = pn.Column(
+                pn.indicators.LoadingSpinner(value=True, width=50, height=50),
+                pn.pane.Markdown("Fetching Data..."),
+                sizing_mode='stretch_width'
+            )
+            
+            # Ensures build after panel server is fully loaded to avoid race conditions
+            pn.state.onload(lambda: asyncio.create_task(asyncio.to_thread(self.build_component)))
+    
+    def build_component(self):
+        df_data = self._build_dataframe()
+        ds_widget = self._build_widget(df_data)
+        
+        self._content[:] = pn.Column(
+            pn.Card(ds_widget, title="Data Catalog Explorer"),
+            self.js_download,
+            sizing_mode="stretch_width"
+        )
+
+    def _build_dataframe(self):
         base_df = pd.DataFrame({
             'Name': [ds.name for ds in self.pipeline.data_catalog],
             'Type': [json.loads(ds.config)["type"] for ds in self.pipeline.data_catalog],
             'Filepath': [json.loads(ds.config).get("filepath", "") for ds in self.pipeline.data_catalog],
-        }, index=[i for i in range(len(self.pipeline.data_catalog))])
-
-        # Create column for each tag
+        })
+        
         tags_list = []
         for idx, ds in enumerate(self.pipeline.data_catalog):
             tag_data = {}
@@ -37,113 +68,27 @@ class DataCatalogExplorer(pn.viewable.Viewer):
                 for tag in ds.tags:
                     tag_data[f"Tag:{tag.key}"] = tag.value
             tags_list.append(pd.Series(tag_data, name=idx))
-
+        
         tags_df = pd.DataFrame(tags_list).fillna("")
-        ds_df = pd.concat([base_df, tags_df], axis=1)
+        return pd.concat([base_df, tags_df], axis=1)
 
-        # this is used to inject JS dynamically
-        js_download = pn.pane.HTML("", width=0, height=0)
-
-        def trigger_popout(url):
-            js_code = f"""
-            <script>
-            (function() {{
-                const a = document.createElement('a');
-                a.href = "{url}";
-                a.target = "_blank";
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-            }})();
-            </script>
-            """
-
-            js_download.object = js_code
-            js_download.object = None
-
-        def trigger_download(url, filepath):
-            js_code = f"""
-            <script>
-            (async function() {{
-                const response = await fetch("{url}");
-                const blob = await response.blob();
-                const url = window.URL.createObjectURL(blob);
-                const link = document.createElement('a');
-                link.href = url;
-                link.setAttribute('download', "{filepath.split("/")[-1]}");
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-                window.URL.revokeObjectURL(url);
-            }})();
-            </script>
-            """
-
-            js_download.object = js_code
-            js_download.object = None
-
-        def open_dataset_viewer(page, presigned_url, ds_name, ds_type):
-            js_code = f"""
-            <script>
-            (function() {{
-                const presigned_url = "{presigned_url}";
-                const page = "{page}";
-                const ds_name = "{ds_name}";
-                const ds_type = "{ds_type}";
-                const viewerUrl = `${{window.location.origin}}/?page=${{page}}&presigned_url=${{encodeURIComponent(presigned_url)}}&ds_name=${{encodeURIComponent(ds_name)}}&ds_type=${{encodeURIComponent(ds_type)}}`;
-                window.open(viewerUrl, '_blank');
-            }})();
-            </script>
-            """
-            js_download.object = js_code
-
-        async def on_row_click(event):
-            row = event.row
-            dataset_name = ds_df.iloc[row]['Name']
-            dataset_filepath = ds_df.iloc[row]['Filepath']
-            dataset_type = ds_df.iloc[row]['Type']
-            if event.column == 'Download':
-                for ds in self.pipeline.data_catalog:
-                    if ds.name == dataset_name:
-                        presigned_urls = await self.spec["config"]["client"].read_datasets(
-                            id=self.pipeline.id, names=[ds.name], expires_in_sec=3600)
-                        presigned_url = presigned_urls[0]
-                        print(f"signed URL for {dataset_name}: {presigned_url}")
-                        if presigned_url:
-                            trigger_download(presigned_url, dataset_filepath)
-                        else:
-                            pn.state.notifications.warning(
-                                f"No signed URL available for {dataset_name}", duration=10000)
-                            return
-            if event.column == 'Popout':
-                for ds in self.pipeline.data_catalog:
-                    if ds.name == dataset_name:
-                        presigned_urls = await self.spec["config"]["client"].read_datasets(
-                            id=self.pipeline.id, names=[ds.name], expires_in_sec=3600)
-                        presigned_url = presigned_urls[0]
-                        for dataset_type, panel_page in self.dataset_map.items():
-                            if json.loads(ds.config)["type"] == dataset_type:
-                                open_dataset_viewer(
-                                    panel_page, presigned_url, dataset_name, dataset_type)
-                                return
-                        if presigned_url:
-                            trigger_popout(presigned_url)
-                        else:
-                            pn.state.notifications.warning(
-                                f"No signed URL available for {dataset_name}", duration=10000)
-                            return
-
+    def _build_widget(self, ds_df):
         filters = {
             "Name": {"type": "input", "placeholder": "Filter by name", "func": "like"},
-            "Type":
-            {"type": "list",
-                "placeholder": "Select dataset type(s)", "func": "in", "valuesLookup": True, "multiselect": True},
-            "Filepath": {"type": "input", "placeholder": "Filter by filepath", "func": "like"}}
-
-        for tag in tags_df.columns.tolist():
-            filters[tag] = {"type": "list", "placeholder": "Select tag(s)",
-                            "func": "in", "valuesLookup": True, "multiselect": True}
-
+            "Type": {"type": "list", "placeholder": "Select dataset type(s)", 
+                    "func": "in", "valuesLookup": True, "multiselect": True},
+            "Filepath": {"type": "input", "placeholder": "Filter by filepath", "func": "like"}
+        }
+        
+        for tag in ds_df.columns[3:]:
+            filters[tag] = {
+                "type": "list",
+                "placeholder": "Select tag(s)",
+                "func": "in",
+                "valuesLookup": True,
+                "multiselect": True
+            }
+        
         ds_widget = pn.widgets.Tabulator(
             ds_df,
             disabled=True,
@@ -156,13 +101,117 @@ class DataCatalogExplorer(pn.viewable.Viewer):
             show_index=False,
             header_filters=filters,
         )
-        ds_widget.on_click(on_row_click)
+        ds_widget.on_click(lambda event: asyncio.create_task(self.on_row_click(event, ds_df)))
+        return ds_widget
+    
+    def trigger_popout(self, url):
+        """
+        Trigger a popout window for the specified URL. Default browser rendering is used.
+        """
 
-        yield pn.Column(
-            pn.Card(ds_widget, title="Data Catalog Explorer",
-                    sizing_mode="stretch_width"),
-            js_download,
-            sizing_mode="stretch_width",)
+        js_code = f"""
+        <script>
+        (function() {{
+            const a = document.createElement('a');
+            a.href = "{url}";
+            a.target = "_blank";
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+        }})();
+        </script>
+        """
+
+        self.js_download.object = js_code
+        self.js_download.object = None
+
+    def trigger_download(self, url, filepath):
+        """
+        Trigger a browser download for the specified URL. Name is derived from the filepath.
+        """
+
+        js_code = f"""
+        <script>
+        (async function() {{
+            const response = await fetch("{url}");
+            const blob = await response.blob();
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', "{filepath.split("/")[-1]}");
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            window.URL.revokeObjectURL(url);
+        }})();
+        </script>
+        """
+
+        self.js_download.object = js_code
+        self.js_download.object = None
+
+    def open_dataset_viewer(self, page, presigned_url, ds_name, ds_type):
+        """
+        Open custom dataset viewer in a new browser tab provided from the dataset_map.
+        """
+
+        js_code = f"""
+        <script>
+        (function() {{
+            const presigned_url = "{presigned_url}";
+            const page = "{page}";
+            const ds_name = "{ds_name}";
+            const ds_type = "{ds_type}";
+            const viewerUrl = `${{window.location.origin}}/?page=${{page}}&presigned_url=${{encodeURIComponent(presigned_url)}}&ds_name=${{encodeURIComponent(ds_name)}}&ds_type=${{encodeURIComponent(ds_type)}}`;
+            window.open(viewerUrl, '_blank');
+        }})();
+        </script>
+        """
+
+        self.js_download.object = js_code
+        self.js_download.object = None
+
+    async def on_row_click(self, event, ds_df):
+        """
+        Handle row click events in the dataset table and triggers appropriate actions for 'Download' or 'Popout' column clicks.
+        """
+
+        if event.column != 'Download' and event.column != 'Popout':
+            return
+
+        row = event.row
+        dataset_name = ds_df.iloc[row]['Name']
+        dataset_filepath = ds_df.iloc[row]['Filepath']
+        dataset_type = ds_df.iloc[row]['Type']
+
+        for ds in self.pipeline.data_catalog:
+            if ds.name == dataset_name:
+                presigned_urls = await self.spec["config"]["client"].read_datasets(
+                    id=self.pipeline.id, names=[ds.name], expires_in_sec=3600)
+                presigned_url = presigned_urls[0]
+
+                if event.column == 'Download':
+                    if presigned_url:
+                        self.trigger_download(presigned_url, dataset_filepath)
+                    else:
+                        pn.state.notifications.warning(
+                            f"No signed URL available for {dataset_name}", duration=10000)
+                    return
+
+                if event.column == 'Popout':
+                    if presigned_url:
+                        # Check dataset_map for custom viewer
+                        for dataset_type, panel_page in self.dataset_map.items():
+                            if json.loads(ds.config)["type"] == dataset_type:
+                                self.open_dataset_viewer(
+                                    panel_page, presigned_url, dataset_name, dataset_type)
+                                return
+                        # Default to raw data viewer
+                        self.trigger_popout(presigned_url)
+                    else:
+                        pn.state.notifications.warning(
+                            f"No signed URL available for {dataset_name}", duration=10000)
+                    return
 
     def __panel__(self):
-        return self.build_component
+        return self._content

--- a/src/kedro_graphql/ui/components/dataset_perspective.py
+++ b/src/kedro_graphql/ui/components/dataset_perspective.py
@@ -1,19 +1,27 @@
+import asyncio
 import panel as pn
 import param
-import asyncio
-from kedro.io import AbstractDataset
 import requests
+from kedro.io import AbstractDataset
 
 pn.extension("perspective")
 
-
 class DatasetPerspective(pn.viewable.Viewer):
-    """A Kedro Dataframe viewer that loads a dataset from a presigned URL and displays it using panel Perspective."""
+    """
+    A Panel component that loads a Kedro dataset from a presigned URL and displays it using pn.pane.Perspective.
 
+    Attributes:
+        spec (dict): Kedro GraphQL UI specification
+        presigned_url (str): The presigned URL to load data from.
+        ds_name (str): The name of the dataset.
+        ds_type (str): The type of the dataset.
+        file_size_limit_mb (int): Maximum file size limit in MB to prevent loading large datasets
+    """
+
+    spec = param.Dict(default={}, doc="Kedro GraphQL UI specification")
     presigned_url = param.String(doc="The presigned URL to load data from")
-    spec = param.Dict(default={})
-    ds_name = param.String(doc="The name of the dataset")
-    ds_type = param.String(doc="The type of the dataset")
+    ds_name = param.String(doc="The name of the Kedro dataset")
+    ds_type = param.String(doc="The type of the Kedro dataset")
     file_size_limit_mb = param.Integer(doc="Maximum file size limit in MB")
 
     def __init__(self, **params):

--- a/src/kedro_graphql/ui/components/pipeline_cards.py
+++ b/src/kedro_graphql/ui/components/pipeline_cards.py
@@ -33,11 +33,11 @@ class PipelineCards(pn.viewable.Viewer):
         """
 
         if event == "run":
-            pn.state.location.pathname = "/" + self.form_page
+            pn.state.location.pathname = self.spec["panel_get_server_kwargs"]["prefix"] + self.form_page
             pn.state.location.search = "?pipeline=" + pipeline + "&form=" + form.__name__
             pn.state.location.reload = True
         elif event == "explore":
-            pn.state.location.pathname = "/" + self.explore_page
+            pn.state.location.pathname = self.spec["panel_get_server_kwargs"]["prefix"] + self.explore_page
             pn.state.location.search = "?pipeline=" + pipeline
             pn.state.location.reload = True
 
@@ -53,16 +53,28 @@ class PipelineCards(pn.viewable.Viewer):
             p_card = pn.Card(title=pipeline, sizing_mode='stretch_width')
             run_button = pn.widgets.Button(name='Run', button_type='success')
             explore_button = pn.widgets.Button(name='Explore', button_type='default')
-            p_card = pn.Card(pipeline, pn.Row(
-                run_button,
-                explore_button
-            ),
-                title=pipeline)
+            p_card = pn.Card(
+                pipeline,
+                pn.Row(run_button, explore_button),
+                title=pipeline
+            )
             p_cards.append(p_card)
-            pn.bind(self.navigate, run_button, event="run",
-                    pipeline=pipeline, form=forms[0], watch=True)
-            pn.bind(self.navigate, explore_button, event="explore",
-                    pipeline=pipeline, form=forms[0], watch=True)
+            pn.bind(
+                self.navigate,
+                run_button,
+                event="run",
+                pipeline=pipeline,
+                form=forms[0],
+                watch=True
+            )
+            pn.bind(
+                self.navigate,
+                explore_button,
+                event="explore",
+                pipeline=pipeline,
+                form=forms[0],
+                watch=True
+            )
 
         yield pn.FlexBox(*p_cards)
 

--- a/src/kedro_graphql/ui/components/pipeline_dashboard_factory.py
+++ b/src/kedro_graphql/ui/components/pipeline_dashboard_factory.py
@@ -10,7 +10,8 @@ from kedro_graphql.ui.components.data_catalog_explorer import DataCatalogExplore
 
 
 class PipelineDashboardFactory(pn.viewable.Viewer):
-    """A factory for building dashboards for Kedro pipelines using registered @ui_dashboard plugins.
+    """
+    A factory for building dashboards for Kedro pipelines using registered @ui_dashboard plugins.
     This component allows users to select a dashboard for a specific pipeline and build the dashboard dynamically.
 
     Attributes:
@@ -19,7 +20,9 @@ class PipelineDashboardFactory(pn.viewable.Viewer):
         options (list): A list of available dashboards for the selected pipeline.
         spec (dict): The specification for the UI, including configuration and pages.
         dashboard_name (str): The name of the selected dashboard.
+        dataset_map (dict): A mapping of Kedro dataset types to their corresponding rendering Panel components.
     """
+
     id = param.String(default="")
     pipeline = param.String(default="")
     options = param.List(default=[])
@@ -30,22 +33,47 @@ class PipelineDashboardFactory(pn.viewable.Viewer):
     def __init__(self, **params):
         super().__init__(**params)
 
+        pn.state.location.sync(
+            self, {"id": "id", "pipeline": "pipeline", "dashboard_name": "dashboard_name"})
+
+        if not self.id or not self.pipeline or not self.spec:
+            self._content = pn.Column(
+                pn.pane.Markdown("**Missing required parameters: `id`, `pipeline`, or `spec`.**"),
+                sizing_mode="stretch_width"
+            )
+        else:
+            # Show loading spinner until the dashboard is built
+            self._content = pn.Column(
+                pn.indicators.LoadingSpinner(value=True, width=50, height=50),
+                pn.pane.Markdown("Fetching Data..."),
+                sizing_mode='stretch_width'
+            )
+            
+            # Ensures build after panel server is fully loaded to avoid race conditions
+            pn.state.onload(self.build_dashboard)
+
     def build_default_dashboard(self, p):
-        """Builds the default dashboard for a Kedro pipeline, including monitoring, detail, and visualization components
+        """
+        Builds the default dashboard for a Kedro pipeline, including monitoring, detail, and visualization components
         registered to the pipeline using the @ui_data plugin.
 
         Args:
             p (Pipeline): The Kedro pipeline for which the dashboard is built.
+
         Returns:
             pn.Tabs: A panel containing tabs for monitoring, detail, and visualization of the pipeline.
         """
+
         monitor = PipelineMonitor(spec=self.spec, pipeline=p)
         detail = PipelineDetail(pipeline=p)
         viz = PipelineViz(pipeline=p.name, spec=self.spec)
         retry = PipelineRetry(client=self.spec["config"]["client"], pipeline=p)
         cloning = PipelineCloning(client=self.spec["config"]["client"], pipeline=p)
         explorer = DataCatalogExplorer(
-            spec=self.spec, pipeline=p, dataset_map=self.dataset_map)
+            spec=self.spec,
+            pipeline=p,
+            dataset_map=self.dataset_map
+        )
         tabs = pn.Tabs(dynamic=False)
         tabs.append(("Explorer", explorer))
         tabs.append(("Monitor", monitor))
@@ -55,18 +83,21 @@ class PipelineDashboardFactory(pn.viewable.Viewer):
         tabs.append(("Cloning", cloning))
         if UI_PLUGINS["DATA"].get(self.pipeline, None):
             for d in UI_PLUGINS["DATA"][self.pipeline]:
-                data = d(id=self.id, spec=self.spec,
-                         pipeline=p)
+                data = d(id=self.id, spec=self.spec, pipeline=p)
                 tabs.append((data.title, data))
         return tabs
 
     def build_custom_dashboard(self, p):
-        """Builds a custom dashboard for a Kedro pipeline using a registered @ui_dashboard plugin.
+        """
+        Builds a custom dashboard for a Kedro pipeline using a registered @ui_dashboard plugin.
+
         Args:
             p (Pipeline): The Kedro pipeline for which the dashboard is built.
+
         Returns:
             panel.viewable.Viewer: An instance of the custom dashboard class.
         """
+
         dash = None
         for d in UI_PLUGINS["DASHBOARD"][self.pipeline]:
             if d.__name__ == self.dashboard_name:
@@ -74,42 +105,34 @@ class PipelineDashboardFactory(pn.viewable.Viewer):
         dash = dash(id=self.id, pipeline=p, spec=self.spec)
         return dash
 
-    @param.depends("spec", "dashboard_name", "id", "pipeline")
     async def build_dashboard(self):
-        """Builds the dashboard for the selected pipeline and dashboard name.
+        """
+        Builds the dashboard for the selected pipeline and dashboard name.
         This method checks if a custom dashboard is registered for the pipeline and builds it accordingly.
         If no custom dashboard is registered, it builds the default dashboard with monitoring, detail, and visualization components.
-
-        Yields:
-            pn.Tabs or panel.viewable.Viewer: The built dashboard, either custom or default.
         """
-        # yield pn.indicators.LoadingSpinner(value=True, width=25, height=25)
-
+        
         p = await self.spec["config"]["client"].read_pipeline(id=self.id)
 
         if UI_PLUGINS["DASHBOARD"].get(self.pipeline, None):
-            yield self.build_custom_dashboard(p)
-        else:
-            yield self.build_default_dashboard(p)
-
-    def __panel__(self):
-
-        pn.state.location.sync(
-            self, {"id": "id", "pipeline": "pipeline", "dashboard_name": "dashboard_name"})
-        if not UI_PLUGINS["DASHBOARD"].get(self.pipeline, None):
-            self.options = []
-        else:
             for f in UI_PLUGINS["DASHBOARD"][self.pipeline]:
                 self.options.append(f.__name__)
+            select = pn.widgets.Select.from_param(
+                self.param.dashboard_name,
+                name='Select a dashboard',
+                options=self.options,
+                value=self.param.dashboard_name
+            )
             self.dashboard_name = self.options[0]
-
-        select = pn.widgets.Select.from_param(self.param.dashboard_name,
-                                              name='Select a dashboard', options=self.options, value=self.param.dashboard_name)
-
-        if len(self.options) > 1:
-            return pn.Column(
+            custom_dashboard = self.build_custom_dashboard(p)
+            self._content[:] = pn.Column(
                 pn.Row(select),
-                pn.Row(self.build_dashboard)
+                pn.Row(custom_dashboard)
             )
         else:
-            return pn.Row(self.build_dashboard)
+            self.options = []
+            default_dashboard = self.build_default_dashboard(p)
+            self._content[:] = pn.Row(default_dashboard)
+
+    def __panel__(self):
+        return self._content

--- a/src/kedro_graphql/ui/components/pipeline_detail.py
+++ b/src/kedro_graphql/ui/components/pipeline_detail.py
@@ -26,7 +26,13 @@ class PipelineDetail(pn.viewable.Viewer):
             pn.Row: A row containing the detail view of the pipeline.
         """
         if "json" in raw:
-            yield pn.Row(pn.widgets.JSONEditor(value=self.pipeline.encode(encoder="dict"), mode="view", width=600))
+            yield pn.Row(
+                pn.widgets.JSONEditor(
+                    value=self.pipeline.encode(encoder="dict"),
+                    mode="view",
+                    width=600
+                )
+            )
         else:
             if self.pipeline.parameters:
                 param_df = pd.DataFrame({
@@ -39,10 +45,12 @@ class PipelineDetail(pn.viewable.Viewer):
                     'value': [],
                 }, index=[])
 
-            param_widget = pn.widgets.Tabulator(param_df,
-                                                disabled=True,
-                                                theme='materialize',
-                                                show_index=False)
+            param_widget = pn.widgets.Tabulator(
+                param_df,
+                disabled=True,
+                theme='materialize',
+                show_index=False
+            )
 
             if self.pipeline.tags:
                 tags_df = pd.DataFrame({
@@ -52,48 +60,55 @@ class PipelineDetail(pn.viewable.Viewer):
             else:
                 tags_df = pd.DataFrame({'key': [], 'value': []})
 
-            tags_widget = pn.widgets.Tabulator(tags_df,
-                                               disabled=True,
-                                               theme='materialize',
-                                               show_index=False)
+            tags_widget = pn.widgets.Tabulator(
+                tags_df,
+                disabled=True,
+                theme='materialize',
+                show_index=False
+            )
 
             if self.pipeline.data_catalog:
-
                 ds_df = pd.DataFrame({
                     'name': [i.name for i in self.pipeline.data_catalog],
                     'type': [json.loads(i.config)["type"] for i in self.pipeline.data_catalog],
                 }, index=[i for i in range(len(self.pipeline.data_catalog))])
             else:
-                # backwards compoatibility, will be deprecated
+                # backwards compatibility, will be deprecated
                 ds_df = pd.DataFrame({
                     'name': [i.name for i in self.pipeline.inputs] + [i.name for i in self.pipeline.outputs],
                     'type': [i.type for i in self.pipeline.inputs] + [i.type for i in self.pipeline.outputs],
                 }, index=[i for i in range(len(self.pipeline.inputs) + len(self.pipeline.outputs))])
 
-            ds_widget = pn.widgets.Tabulator(ds_df,
-                                             disabled=True,
-                                             buttons={
-                                                 'Download': "<i class='fa fa-download'></i>"},
-                                             theme='materialize',
-                                             show_index=False)
+            ds_widget = pn.widgets.Tabulator(
+                ds_df,
+                disabled=True,
+                buttons={'Download': "<i class='fa fa-download'></i>"},
+                theme='materialize',
+                show_index=False
+            )
 
-            # in the future this be a list of PipelineStatus objects
+            # in the future this will be a list of PipelineStatus objects
             # for now we grab each attribute from Pipeline object
 
-            cols = ["state", "task_id", "task_name", "task_args", "task_kwargs", "task_request",
-                    "task_excpetion", "task_traceback", "task_einfo", "task_self.pipeline"]
+            cols = [
+                "state", "task_id", "task_name", "task_args", "task_kwargs",
+                "task_request", "task_excpetion", "task_traceback", "task_einfo", "task_self.pipeline"
+            ]
             values = self.pipeline.encode(encoder="dict")["status"]
 
             status_df = pd.DataFrame(
                 values,
                 columns=cols,
-                index=[i for i in range(len(values))])
+                index=[i for i in range(len(values))]
+            )
 
-            status_widget = pn.widgets.Tabulator(status_df,
-                                                 disabled=True,
-                                                 theme='materialize',
-                                                 layout='fit_columns',
-                                                 show_index=False)
+            status_widget = pn.widgets.Tabulator(
+                status_df,
+                disabled=True,
+                theme='materialize',
+                layout='fit_columns',
+                show_index=False
+            )
 
             yield pn.Column(
                 pn.Row(
@@ -130,11 +145,7 @@ class PipelineDetail(pn.viewable.Viewer):
         raw = pn.widgets.CheckButtonGroup(name='JSON', value=[], options=["json"])
         detail = pn.bind(self.build_detail, raw)
         return pn.Column(
-            pn.Row(
-                raw
-            ),
-            pn.Row(
-                detail
-            ),
+            pn.Row(raw),
+            pn.Row(detail),
             sizing_mode="stretch_width"
         )

--- a/src/kedro_graphql/ui/components/pipeline_monitor.py
+++ b/src/kedro_graphql/ui/components/pipeline_monitor.py
@@ -32,7 +32,10 @@ class PipelineMonitor(param.Parameterized):
             cookies = None
 
         self.client = KedroGraphqlClient(
-            uri_graphql=spec["config"]["client_uri_graphql"], uri_ws=spec["config"]["client_uri_ws"], cookies=cookies)
+            uri_graphql=spec["config"]["client_uri_graphql"],
+            uri_ws=spec["config"]["client_uri_ws"],
+            cookies=cookies
+        )
         self.pipeline = pipeline
 
     @param.depends('pipeline', watch=True)
@@ -62,8 +65,17 @@ class PipelineMonitor(param.Parameterized):
     def __panel__(self):
         return pn.Column(
             pn.Param(
-                self, name="", parameters=["status", "logs"],
-                widgets={"status": pn.widgets.StaticText,
-                         "logs": pn.widgets.TextAreaInput(name="Live Log Stream", sizing_mode='stretch_width', height=400)}),
+                self,
+                name="",
+                parameters=["status", "logs"],
+                widgets={
+                    "status": pn.widgets.StaticText,
+                    "logs": pn.widgets.TextAreaInput(
+                        name="Live Log Stream",
+                        sizing_mode='stretch_width',
+                        height=400
+                    )
+                }
+            ),
             sizing_mode='stretch_width'
         )

--- a/src/kedro_graphql/ui/components/pipeline_viz.py
+++ b/src/kedro_graphql/ui/components/pipeline_viz.py
@@ -35,12 +35,16 @@ class PipelineViz(pn.viewable.Viewer):
             pn.pane.HTML: The HTML pane containing the iframe for the pipeline visualization.
         """
         iframe = """
-        <iframe frameBorder="0"  style="height:100%; width:100%" src="http://localhost:5006/pipeline/viz-build/index.html?pid={pipeline}"></iframe>
-        """.format(pipeline=self.pipeline)
+        <iframe frameBorder="0" style="height:100%; width:100%" src="{prefix}pipeline/viz-build/index.html?pid={pipeline}"></iframe>
+        """.format(pipeline=self.pipeline, prefix=self.spec["panel_get_server_kwargs"]["prefix"])
         if self.sid:
             iframe = """
-            <iframe frameBorder="0" style="height:100%; width:100%" src="http://localhost:5006/pipeline/viz-build/index.html?pid={pipeline}&sid={sid}"></iframe>
-            """.format(pipeline=self.pipeline, sid=self.sid)
+            <iframe frameBorder="0" style="height:100%; width:100%" src="{prefix}pipeline/viz-build/index.html?pid={pipeline}&sid={sid}"></iframe>
+            """.format(
+                pipeline=self.pipeline,
+                sid=self.sid,
+                prefix=self.spec["panel_get_server_kwargs"]["prefix"]
+            )
 
         yield pn.pane.HTML(iframe, height=self.height, sizing_mode="stretch_width")
 

--- a/src/kedro_graphql/ui/components/template.py
+++ b/src/kedro_graphql/ui/components/template.py
@@ -30,8 +30,8 @@ class NavigationSidebarButton(pn.viewable.Viewer):
 
     def navigate(self, event):
         """Navigate to the specified page."""
-        pn.state.location.pathname = self.spec["panel_get_server_kwargs"]["base_url"]
-        pn.state.location.search = "?page="+self.name.lower()
+        pn.state.location.pathname = self.spec["panel_get_server_kwargs"]["prefix"]
+        pn.state.location.search = "?page=" + self.name.lower()
 
     async def build_button(self):
         """Builds the navigation button for the sidebar.
@@ -48,7 +48,11 @@ class NavigationSidebarButton(pn.viewable.Viewer):
             b0_icon = None
 
         button = pn.widgets.Button(
-            name=self.name, button_type=b0_type, sizing_mode="stretch_width", icon=b0_icon)
+            name=self.name,
+            button_type=b0_type,
+            sizing_mode="stretch_width",
+            icon=b0_icon
+        )
         pn.bind(self.navigate, button, watch=True)
         return button
 
@@ -129,10 +133,12 @@ class KedroGraphqlMaterialTemplate(pn.template.MaterialTemplate):
         """
         # if hasattr(pn.state, "user_info") and pn.state.user_info:
         # user = pn.state.user_info.get("name", False) or pn.state.user or "Guest"
-        if pn.state.headers.get("X-Forwarded-User", None):
-            user = pn.state.headers.get("X-Forwarded-User", None)
-            email = pn.state.headers.get("X-Forwarded-Email", None)
-            groups = pn.state.headers.get("X-Forwarded-Groups", None)
+
+        user = pn.state.headers.get("X-Forwarded-User", None) or pn.state.headers.get("X-Auth-Request-User", None)
+
+        if user:
+            email = pn.state.headers.get("X-Forwarded-Email", None) or pn.state.headers.get("X-Auth-Request-Email", None)
+            groups = pn.state.headers.get("X-Forwarded-Groups", None) or pn.state.headers.get("X-Auth-Request-Groups", None)
             user_info = {"user": user, "email": email, "groups": groups}
         else:
             user = "Guest"
@@ -176,7 +182,10 @@ class KedroGraphqlMaterialTemplate(pn.template.MaterialTemplate):
             cookies = None
 
         client = KedroGraphqlClient(
-            uri_graphql=spec["config"]["client_uri_graphql"], uri_ws=spec["config"]["client_uri_ws"], cookies=cookies)
+            uri_graphql=spec["config"]["client_uri_graphql"],
+            uri_ws=spec["config"]["client_uri_ws"],
+            cookies=cookies
+        )
 
         spec["config"]["client"] = client
         return spec
@@ -200,7 +209,7 @@ class KedroGraphqlMaterialTemplate(pn.template.MaterialTemplate):
             self.sidebar.append(next_button)
 
         self.main.append(pn.Column(TemplateMainFactory(spec=spec)))
-        # pn.state.location.pathname = spec["panel_get_server_kwargs"]["base_url"]
+        # pn.state.location.pathname = spec["panel_get_server_kwargs"]["prefix"]
         pn.state.location.sync(
             self, {"page": "page"})
 
@@ -221,7 +230,7 @@ class NavigationSidebarButtonV2(pn.viewable.Viewer):
 
     def navigate(self, event):
         """Navigate to the specified page."""
-        pn.state.location.pathname = "/" + self.name.lower()
+        pn.state.location.pathname = self.spec["panel_get_server_kwargs"]["prefix"] + self.name.lower()
         pn.state.location.search = ""
         pn.state.location.reload = True
 
@@ -240,7 +249,11 @@ class NavigationSidebarButtonV2(pn.viewable.Viewer):
             b0_icon = None
 
         button = pn.widgets.Button(
-            name=self.name, button_type=b0_type, sizing_mode="stretch_width", icon=b0_icon)
+            name=self.name,
+            button_type=b0_type,
+            sizing_mode="stretch_width",
+            icon=b0_icon
+        )
         pn.bind(self.navigate, button, watch=True)
         yield button
 
@@ -285,10 +298,12 @@ class KedroGraphqlMaterialTemplateV2(pn.template.MaterialTemplate):
         """Asynchronously retrieves the user context for the template.
         This method can be overridden to provide custom user context data.
         """
-        if pn.state.headers.get("X-Forwarded-User", None):
-            user = pn.state.headers.get("X-Forwarded-User", None)
-            email = pn.state.headers.get("X-Forwarded-Email", None)
-            groups = pn.state.headers.get("X-Forwarded-Groups", None)
+        
+        user = pn.state.headers.get("X-Forwarded-User", None) or pn.state.headers.get("X-Auth-Request-User", None)
+
+        if user:
+            email = pn.state.headers.get("X-Forwarded-Email", None) or pn.state.headers.get("X-Auth-Request-Email", None)
+            groups = pn.state.headers.get("X-Forwarded-Groups", None) or pn.state.headers.get("X-Auth-Request-Groups", None)
             user_info = {"user": user, "email": email, "groups": groups}
         else:
             user = "Guest"
@@ -332,7 +347,10 @@ class KedroGraphqlMaterialTemplateV2(pn.template.MaterialTemplate):
             cookies = None
 
         client = KedroGraphqlClient(
-            uri_graphql=spec["config"]["client_uri_graphql"], uri_ws=spec["config"]["client_uri_ws"], cookies=cookies)
+            uri_graphql=spec["config"]["client_uri_graphql"],
+            uri_ws=spec["config"]["client_uri_ws"],
+            cookies=cookies
+        )
 
         spec["config"]["client"] = client
         return spec
@@ -345,6 +363,7 @@ class KedroGraphqlMaterialTemplateV2(pn.template.MaterialTemplate):
         """
         super().__init__(
             title=spec["panel_get_server_kwargs"]["title"],
+            base_url=spec["panel_get_server_kwargs"]["prefix"],
             sidebar_width=200)
 
         self.spec = self.init_client(spec)

--- a/src/kedro_graphql/ui/decorators.py
+++ b/src/kedro_graphql/ui/decorators.py
@@ -12,17 +12,7 @@ def discover_plugins(config):
     Args:
         config (dict): Configuration dictionary containing the imports.
     """
-    kedro_imports = config["KEDRO_GRAPHQL_IMPORTS"]
-    
-    # Handle both string and list types
-    if isinstance(kedro_imports, str):
-        imports = [i.strip() for i in kedro_imports.split(",") if len(i.strip()) > 0]
-    elif isinstance(kedro_imports, list):
-        imports = [i.strip() for i in kedro_imports if len(i.strip()) > 0]
-    else:
-        imports = []
-    
-    for i in imports:
+    for i in config["KEDRO_GRAPHQL_IMPORTS"]:
         import_module(i)
 
 

--- a/src/kedro_graphql/ui/decorators.py
+++ b/src/kedro_graphql/ui/decorators.py
@@ -12,8 +12,16 @@ def discover_plugins(config):
     Args:
         config (dict): Configuration dictionary containing the imports.
     """
-    imports = [i.strip()
-               for i in config["KEDRO_GRAPHQL_IMPORTS"].split(",") if len(i.strip()) > 0]
+    kedro_imports = config["KEDRO_GRAPHQL_IMPORTS"]
+    
+    # Handle both string and list types
+    if isinstance(kedro_imports, str):
+        imports = [i.strip() for i in kedro_imports.split(",") if len(i.strip()) > 0]
+    elif isinstance(kedro_imports, list):
+        imports = [i.strip() for i in kedro_imports if len(i.strip()) > 0]
+    else:
+        imports = []
+    
     for i in imports:
         import_module(i)
 

--- a/src/kedro_graphql/ui/plugins.py
+++ b/src/kedro_graphql/ui/plugins.py
@@ -49,7 +49,7 @@ class BaseExample00Form(pn.viewable.Viewer):
 
     def navigate(self, pipeline_id: str):
         """Navigate to the pipeline dashboard with the given ID."""
-        pn.state.location.pathname = "/dashboard"
+        pn.state.location.pathname = self.spec["panel_get_server_kwargs"]["prefix"] + "dashboard"
         pn.state.location.search = "?pipeline=example00&id=" + pipeline_id
         pn.state.location.reload = True
 
@@ -73,11 +73,18 @@ class BaseExample00Form(pn.viewable.Viewer):
         return PipelineInput(**{
             "name": "example00",
             "state": "STAGED",
-            "data_catalog": [{"name": "text_in", "config": json.dumps(input_dict)},
-                             {"name": "text_out", "config": json.dumps(output_dict)}],
-            "parameters": [{"name": "example", "value": self.example},
-                           {"name": "duration", "value": str(self.duration), "type": "FLOAT"}],
-            "tags": [{"key": "author", "value": "opensean"}, {"key": "package", "value": "kedro-graphql"}]
+            "data_catalog": [
+                {"name": "text_in", "config": json.dumps(input_dict)},
+                {"name": "text_out", "config": json.dumps(output_dict)}
+            ],
+            "parameters": [
+                {"name": "example", "value": self.example},
+                {"name": "duration", "value": str(self.duration), "type": "FLOAT"}
+            ],
+            "tags": [
+                {"key": "author", "value": "opensean"},
+                {"key": "package", "value": "kedro-graphql"}
+            ]
         })
 
     @param.depends('disabled')
@@ -311,7 +318,7 @@ class BaseExample01Form(pn.viewable.Viewer):
 
     def navigate(self, pipeline_id: str):
         """Navigate to the pipeline dashboard with the given ID."""
-        pn.state.location.pathname = "/dashboard"
+        pn.state.location.pathname = self.spec["panel_get_server_kwargs"]["prefix"] + "dashboard"
         pn.state.location.search = "?pipeline=example00&id=" + pipeline_id
         pn.state.location.reload = True
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -1,0 +1,386 @@
+"""
+Tests for the configuration system.
+
+This module tests configuration precedence, complex data type parsing,
+and edge cases for the kedro-graphql configuration system.
+"""
+import json
+import os
+import yaml
+from unittest.mock import patch, mock_open
+import pytest
+
+from kedro_graphql.config import load_config, env_var_parser, load_api_spec, defaults
+
+
+class TestConfigurationPrecedence:
+    """Test configuration precedence order."""
+
+    def test_defaults_only(self):
+        """Test that defaults work when no other config is provided."""
+        with patch.dict(os.environ, {}, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value={}), \
+             patch('kedro_graphql.config.load_api_spec', return_value={}):
+            
+            config = load_config()
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == "Kedro GraphQL API"
+            assert config["KEDRO_GRAPHQL_IMPORTS"] == ["kedro_graphql.plugins.plugins"]
+
+    def test_env_var_overrides_defaults(self):
+        """Test that environment variables override defaults."""
+        env_vars = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Custom Title from Env",
+            "KEDRO_GRAPHQL_MONGO_URI": "mongodb://custom:27017/"
+        }
+        
+        with patch.dict(os.environ, env_vars, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value={}), \
+             patch('kedro_graphql.config.load_api_spec', return_value={}):
+            
+            config = load_config()
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == "Custom Title from Env"
+            assert config["KEDRO_GRAPHQL_MONGO_URI"] == "mongodb://custom:27017/"
+            # Defaults should still be there for non-overridden values
+            assert config["KEDRO_GRAPHQL_BACKEND"] == defaults["KEDRO_GRAPHQL_BACKEND"]
+
+    def test_dotenv_overrides_defaults(self):
+        """Test that .env file values override defaults."""
+        dotenv_values = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from dotenv",
+            "KEDRO_GRAPHQL_BROKER": "redis://dotenv:6379"
+        }
+        
+        with patch.dict(os.environ, {}, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value=dotenv_values), \
+             patch('kedro_graphql.config.load_api_spec', return_value={}):
+            
+            config = load_config()
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == "Title from dotenv"
+            assert config["KEDRO_GRAPHQL_BROKER"] == "redis://dotenv:6379"
+
+    def test_env_var_overrides_dotenv(self):
+        """Test that environment variables override .env file values."""
+        dotenv_values = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from dotenv",
+            "KEDRO_GRAPHQL_BROKER": "redis://dotenv:6379"
+        }
+        env_vars = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from env var"
+        }
+        
+        with patch.dict(os.environ, env_vars, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value=dotenv_values), \
+             patch('kedro_graphql.config.load_api_spec', return_value={}):
+            
+            config = load_config()
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == "Title from env var"  # env var wins
+            assert config["KEDRO_GRAPHQL_BROKER"] == "redis://dotenv:6379"  # dotenv for non-conflicting
+
+    def test_cli_config_overrides_env_var(self):
+        """Test that CLI config overrides environment variables."""
+        env_vars = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from env var",
+            "KEDRO_GRAPHQL_MONGO_URI": "mongodb://env:27017/"
+        }
+        cli_config = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from CLI"
+        }
+        
+        with patch.dict(os.environ, env_vars, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value={}), \
+             patch('kedro_graphql.config.load_api_spec', return_value={}):
+            
+            config = load_config(cli_config=cli_config)
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == "Title from CLI"  # CLI wins
+            assert config["KEDRO_GRAPHQL_MONGO_URI"] == "mongodb://env:27017/"  # env for non-conflicting
+
+    def test_yaml_spec_overrides_cli_config(self):
+        """Test that YAML spec has highest precedence."""
+        env_vars = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from env var"
+        }
+        cli_config = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from CLI",
+            "KEDRO_GRAPHQL_BROKER": "redis://cli:6379"
+        }
+        yaml_config = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from YAML"
+        }
+        
+        with patch.dict(os.environ, env_vars, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value={}), \
+             patch('kedro_graphql.config.load_api_spec', return_value=yaml_config):
+            
+            config = load_config(cli_config=cli_config)
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == "Title from YAML"  # YAML wins
+            assert config["KEDRO_GRAPHQL_BROKER"] == "redis://cli:6379"  # CLI for non-conflicting
+
+    def test_full_precedence_chain(self):
+        """Test complete precedence chain with all sources."""
+        dotenv_values = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from dotenv",
+            "KEDRO_GRAPHQL_BROKER": "redis://dotenv:6379",
+            "KEDRO_GRAPHQL_BACKEND": "backend.from.dotenv"
+        }
+        env_vars = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from env",
+            "KEDRO_GRAPHQL_BROKER": "redis://env:6379"
+        }
+        cli_config = {
+            "KEDRO_GRAPHQL_APP_TITLE": "Title from CLI"
+        }
+        yaml_config = {
+            "KEDRO_GRAPHQL_MONGO_URI": "mongodb://yaml:27017/"
+        }
+        
+        with patch.dict(os.environ, env_vars, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value=dotenv_values), \
+             patch('kedro_graphql.config.load_api_spec', return_value=yaml_config):
+            
+            config = load_config(cli_config=cli_config)
+            
+            # YAML spec (highest precedence)
+            assert config["KEDRO_GRAPHQL_MONGO_URI"] == "mongodb://yaml:27017/"
+            
+            # CLI config (second highest)
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == "Title from CLI"
+            
+            # Environment variable (third)
+            assert config["KEDRO_GRAPHQL_BROKER"] == "redis://env:6379"
+            
+            # .env file (fourth)
+            assert config["KEDRO_GRAPHQL_BACKEND"] == "backend.from.dotenv"
+
+
+class TestComplexDataTypeParsing:
+    """Test parsing of complex data types (lists, dictionaries)."""
+
+    def test_list_field_comma_separated_string(self):
+        """Test parsing comma-separated strings for list fields."""
+        config = {
+            "KEDRO_GRAPHQL_IMPORTS": "module1.plugin,module2.plugin,module3.plugin",
+            "KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS": "./data,/var,/tmp"
+        }
+        
+        parsed = env_var_parser(config)
+        
+        assert parsed["KEDRO_GRAPHQL_IMPORTS"] == ["module1.plugin", "module2.plugin", "module3.plugin"]
+        assert parsed["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS"] == ["./data", "/var", "/tmp"]
+
+    def test_list_field_json_array(self):
+        """Test parsing JSON arrays for list fields."""
+        config = {
+            "KEDRO_GRAPHQL_IMPORTS": '["module1.plugin", "module2.plugin"]',
+            "KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_ALLOWED_ROOTS": '["./data", "./uploads"]'
+        }
+        
+        parsed = env_var_parser(config)
+        
+        assert parsed["KEDRO_GRAPHQL_IMPORTS"] == ["module1.plugin", "module2.plugin"]
+        assert parsed["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_ALLOWED_ROOTS"] == ["./data", "./uploads"]
+
+    def test_list_field_single_value(self):
+        """Test parsing single values that should become single-item lists."""
+        config = {
+            "KEDRO_GRAPHQL_IMPORTS": "single.module",
+            "KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_ALLOWED_ROOTS": "./uploads"
+        }
+        
+        parsed = env_var_parser(config)
+        
+        assert parsed["KEDRO_GRAPHQL_IMPORTS"] == ["single.module"]
+        assert parsed["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_ALLOWED_ROOTS"] == ["./uploads"]
+
+    def test_list_field_empty_string(self):
+        """Test parsing empty strings for list fields."""
+        config = {
+            "KEDRO_GRAPHQL_IMPORTS": "",
+            "KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS": "   "  # whitespace only
+        }
+        
+        parsed = env_var_parser(config)
+        
+        assert parsed["KEDRO_GRAPHQL_IMPORTS"] == []
+        assert parsed["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS"] == []
+
+    def test_list_field_mixed_whitespace(self):
+        """Test parsing comma-separated strings with mixed whitespace."""
+        config = {
+            "KEDRO_GRAPHQL_IMPORTS": " module1 , module2,  module3  ,, module4 ",
+            "KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS": "./data, /var , /tmp,"
+        }
+        
+        parsed = env_var_parser(config)
+        
+        # Empty elements should be filtered out
+        assert parsed["KEDRO_GRAPHQL_IMPORTS"] == ["module1", "module2", "module3", "module4"]
+        assert parsed["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_DOWNLOAD_ALLOWED_ROOTS"] == ["./data", "/var", "/tmp"]
+
+    def test_json_field_dictionary(self):
+        """Test parsing JSON dictionaries for complex fields."""
+        config = {
+            "KEDRO_GRAPHQL_EVENTS_CONFIG": '{"event1": {"source": "app", "type": "test"}}',
+            "KEDRO_GRAPHQL_PERMISSIONS_ROLE_TO_ACTION_MAP": '{"admin": ["create", "read"], "viewer": ["read"]}'
+        }
+        
+        parsed = env_var_parser(config)
+        
+        expected_events = {"event1": {"source": "app", "type": "test"}}
+        expected_permissions = {"admin": ["create", "read"], "viewer": ["read"]}
+        
+        assert parsed["KEDRO_GRAPHQL_EVENTS_CONFIG"] == expected_events
+        assert parsed["KEDRO_GRAPHQL_PERMISSIONS_ROLE_TO_ACTION_MAP"] == expected_permissions
+
+    def test_json_field_invalid_json(self):
+        """Test handling of invalid JSON in JSON fields."""
+        config = {
+            "KEDRO_GRAPHQL_EVENTS_CONFIG": '{"invalid": json}',  # Invalid JSON
+            "KEDRO_GRAPHQL_PERMISSIONS_GROUP_TO_ROLE_MAP": 'not json at all'
+        }
+        
+        with patch('kedro_graphql.config.logger') as mock_logger:
+            parsed = env_var_parser(config)
+            
+            # Should remain as original string when JSON parsing fails
+            assert parsed["KEDRO_GRAPHQL_EVENTS_CONFIG"] == '{"invalid": json}'
+            assert parsed["KEDRO_GRAPHQL_PERMISSIONS_GROUP_TO_ROLE_MAP"] == 'not json at all'
+            
+            # Should log warnings
+            assert mock_logger.warning.call_count == 2
+
+    def test_list_field_complex_json_array(self):
+        """Test parsing complex JSON arrays with nested objects."""
+        config = {
+            "KEDRO_GRAPHQL_IMPORTS": '[{"module": "plugin1", "config": {"enabled": true}}, "simple.module"]'
+        }
+        
+        parsed = env_var_parser(config)
+        
+        expected = [{"module": "plugin1", "config": {"enabled": True}}, "simple.module"]
+        assert parsed["KEDRO_GRAPHQL_IMPORTS"] == expected
+
+    def test_non_string_values_remain_unchanged(self):
+        """Test that non-string values in config remain unchanged."""
+        config = {
+            "KEDRO_GRAPHQL_IMPORTS": ["already", "a", "list"],
+            "KEDRO_GRAPHQL_EVENTS_CONFIG": {"already": "a", "dict": True},
+            "KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_MAX_FILE_SIZE_MB": 10,  # integer
+        }
+        
+        parsed = env_var_parser(config)
+        
+        # Should remain as-is
+        assert parsed["KEDRO_GRAPHQL_IMPORTS"] == ["already", "a", "list"]
+        assert parsed["KEDRO_GRAPHQL_EVENTS_CONFIG"] == {"already": "a", "dict": True}
+        assert parsed["KEDRO_GRAPHQL_LOCAL_FILE_PROVIDER_UPLOAD_MAX_FILE_SIZE_MB"] == 10
+
+
+class TestYAMLSpecLoading:
+    """Test YAML specification file loading."""
+
+    def test_no_api_spec_env_var(self):
+        """Test behavior when no API spec environment variable is set."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = load_api_spec()
+            assert result == {}
+
+    def test_api_spec_file_not_found(self):
+        """Test behavior when API spec file doesn't exist."""
+        with patch.dict(os.environ, {"KEDRO_GRAPHQL_API_SPEC": "/nonexistent/file.yaml"}):
+            with pytest.raises(FileNotFoundError):
+                load_api_spec()
+
+    def test_api_spec_invalid_yaml(self):
+        """Test behavior with invalid YAML content."""
+        invalid_yaml = "invalid: yaml: content: [unclosed"
+        
+        with patch.dict(os.environ, {"KEDRO_GRAPHQL_API_SPEC": "test.yaml"}), \
+             patch("builtins.open", mock_open(read_data=invalid_yaml)), \
+             patch('kedro_graphql.config.logger') as mock_logger:
+            
+            # Should handle gracefully and return empty dict
+            result = load_api_spec()
+            assert result == {}
+            
+            # Should log the error
+            mock_logger.error.assert_called_once()
+
+    def test_api_spec_valid_yaml(self):
+        """Test successful YAML spec loading."""
+        yaml_content = """
+config:
+  app_title: "Custom App Title"
+  mongo_uri: "mongodb://yaml:27017/"
+  imports:
+    - "custom.plugin1"
+    - "custom.plugin2"
+  events_config:
+    event1:
+      source: "yaml.source"
+      type: "yaml.event"
+"""
+        
+        with patch.dict(os.environ, {"KEDRO_GRAPHQL_API_SPEC": "test.yaml"}), \
+             patch("builtins.open", mock_open(read_data=yaml_content)), \
+             patch('kedro_graphql.config.import_module') as mock_import:
+            
+            result = load_api_spec()
+            
+            expected = {
+                "KEDRO_GRAPHQL_APP_TITLE": "Custom App Title",
+                "KEDRO_GRAPHQL_MONGO_URI": "mongodb://yaml:27017/",
+                "KEDRO_GRAPHQL_IMPORTS": ["custom.plugin1", "custom.plugin2"],
+                "KEDRO_GRAPHQL_EVENTS_CONFIG": {
+                    "event1": {"source": "yaml.source", "type": "yaml.event"}
+                }
+            }
+            
+            assert result == expected
+            
+            # Should import the specified modules
+            mock_import.assert_any_call("custom.plugin1")
+            mock_import.assert_any_call("custom.plugin2")
+
+    def test_api_spec_imports_comma_separated_string(self):
+        """Test YAML spec with imports as comma-separated string."""
+        yaml_content = """
+config:
+  imports: "plugin1,plugin2,plugin3"
+  app_title: "Test App"
+"""
+        
+        with patch.dict(os.environ, {"KEDRO_GRAPHQL_API_SPEC": "test.yaml"}), \
+             patch("builtins.open", mock_open(read_data=yaml_content)), \
+             patch('kedro_graphql.config.import_module') as mock_import:
+            
+            result = load_api_spec()
+            
+            assert result["KEDRO_GRAPHQL_IMPORTS"] == "plugin1,plugin2,plugin3"
+            
+            # Should import each module
+            mock_import.assert_any_call("plugin1")
+            mock_import.assert_any_call("plugin2")
+            mock_import.assert_any_call("plugin3")
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_none_cli_config(self):
+        """Test that None cli_config is handled properly."""
+        with patch.dict(os.environ, {}, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value={}), \
+             patch('kedro_graphql.config.load_api_spec', return_value={}):
+            
+            # Should not raise an error
+            config = load_config(cli_config=None)
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == defaults["KEDRO_GRAPHQL_APP_TITLE"]
+
+    def test_empty_cli_config(self):
+        """Test that empty cli_config works properly."""
+        with patch.dict(os.environ, {}, clear=True), \
+             patch('kedro_graphql.config.dotenv_values', return_value={}), \
+             patch('kedro_graphql.config.load_api_spec', return_value={}):
+            
+            config = load_config(cli_config={})
+            assert config["KEDRO_GRAPHQL_APP_TITLE"] == defaults["KEDRO_GRAPHQL_APP_TITLE"]


### PR DESCRIPTION
Added:

- command-line flags for all configuration options, including complex data types support using JSON strings
- proper configuration loading order (YAML spec > CLI flags > Environment variables > .env file > Defaults)
- support for comma-separated strings, JSON arrays, and single values for list-type configuration options
- `test_config.py` with unit tests for configuration precedence and data type parsing scenarios
- `root_path` configuration option to support API endpoint prefixing
- support for both `X-Forwarded-*` and `x-auth-request-*` header formats for OAuth2 proxy compatibility

Changed:

- `configuration.md` with alphabetical ordering and detailed examples for different data types
- alphabetically sorted all spec-*.yaml files
- some panel UI components for better async handling and loading states using `pn.state.onload`

Removed:

- some outdated documentation

Fixed:

- proper error handling in load_api_spec() to prevent crashes on YAML parsing errors
- race conditions in Panel components by ensuring proper loading order
- S3 provider key handling for files without directory prefixes
- panel server kwargs configuration in UI specs