### PR TITLE
added defaults to unique_paths for create_pipeline and update_pipelin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Fixed:
 - race conditions in Panel components by ensuring proper loading order
 - S3 provider key handling for files without directory prefixes
 - panel server kwargs configuration in UI specs
+- made `unique_paths` parameter optional with default `None` in `create_pipeline` and `update_pipeline` mutations to fix issue where passing empty string `""` was converted to `['']` (a truthy list) causing unexpected calls to `generate_unique_paths`
 
 ## [1.1.1] - 2025-08-01
 

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -210,7 +210,7 @@ class Query:
 @strawberry.type
 class Mutation:
     @strawberry.mutation(description="Execute a pipeline.", extensions=[PermissionExtension(permissions=[PERMISSIONS_CLASS(action="create_pipeline")])])
-    def create_pipeline(self, pipeline: PipelineInput, unique_paths: Optional[List[str]], info: Info) -> Pipeline:
+    def create_pipeline(self, pipeline: PipelineInput, info: Info, unique_paths: Optional[List[str]] = None) -> Pipeline:
         """
         - is validation against template needed, e.g. check DataSet type or at least check dataset names
         """
@@ -294,7 +294,7 @@ class Mutation:
             return p
 
     @strawberry.mutation(description="Update a pipeline.", extensions=[PermissionExtension(permissions=[PERMISSIONS_CLASS(action="update_pipeline")])])
-    def update_pipeline(self, id: str, pipeline: PipelineInput, unique_paths: Optional[List[str]], info: Info) -> Pipeline:
+    def update_pipeline(self, id: str, pipeline: PipelineInput, info: Info, unique_paths: Optional[List[str]] = None) -> Pipeline:
 
         try:
             p = info.context["request"].app.backend.read(id=id)


### PR DESCRIPTION
Fixed

- made `unique_paths` parameter optional with default `None` in `create_pipeline` and `update_pipeline` mutations to fix issue where passing empty string `""` was converted to `['']` (a truthy list) causing unexpected calls to `generate_unique_paths`