### PR TITLE
updated conf source and env to use merged config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Fixed:
 - S3 provider key handling for files without directory prefixes
 - panel server kwargs configuration in UI specs
 - made `unique_paths` parameter optional with default `None` in `create_pipeline` and `update_pipeline` mutations to fix issue where passing empty string `""` was converted to `['']` (a truthy list) causing unexpected calls to `generate_unique_paths`
+- configuration loading where CLI defaults for `conf_source` and `env` were being passed directly to `start_app` and `start_worker` instead of using the values from the merged configuration that includes the YAML spec file.
 
 ## [1.1.1] - 2025-08-01
 

--- a/src/kedro_graphql/commands.py
+++ b/src/kedro_graphql/commands.py
@@ -180,15 +180,15 @@ def gql(metadata, app, app_title, app_description, backend, broker, celery_resul
     elif worker:
         if reload:
             run_process(str(reload_path), target=start_worker, args=(
-                config["KEDRO_GRAPHQL_APP"], config, conf_source, env, metadata.package_name, metadata.project_path))
+                config["KEDRO_GRAPHQL_APP"], config, config["KEDRO_GRAPHQL_CONF_SOURCE"], config["KEDRO_GRAPHQL_ENV"], metadata.package_name, metadata.project_path))
         else:
-            start_worker(config["KEDRO_GRAPHQL_APP"], config, conf_source, env,
+            start_worker(config["KEDRO_GRAPHQL_APP"], config, config["KEDRO_GRAPHQL_CONF_SOURCE"], config["KEDRO_GRAPHQL_ENV"],
                          metadata.package_name, metadata.project_path)
 
     else:
         if reload:
-            run_process(reload_path, target=start_app, args=(config["KEDRO_GRAPHQL_APP"], config, conf_source,
-                        env, metadata.package_name, metadata.project_path))
+            run_process(reload_path, target=start_app, args=(config["KEDRO_GRAPHQL_APP"], config, config["KEDRO_GRAPHQL_CONF_SOURCE"],
+                        config["KEDRO_GRAPHQL_ENV"], metadata.package_name, metadata.project_path))
         else:
-            start_app(config["KEDRO_GRAPHQL_APP"], config, conf_source, env,
+            start_app(config["KEDRO_GRAPHQL_APP"], config, config["KEDRO_GRAPHQL_CONF_SOURCE"], config["KEDRO_GRAPHQL_ENV"],
                       metadata.package_name, metadata.project_path)


### PR DESCRIPTION
fixed

- configuration loading where CLI defaults for `conf_source` and `env` were being passed directly to `start_app` and `start_worker` instead of using the values from the merged configuration that includes the YAML spec file.