### PR TITLE
added documentation and cli flags kedro client uri and ws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Added:
 - `test_config.py` with unit tests for configuration precedence and data type parsing scenarios
 - `root_path` configuration option to support API endpoint prefixing
 - support for both `X-Forwarded-*` and `x-auth-request-*` header formats for OAuth2 proxy compatibility
+- client URI configuration options for GraphQL client (`client_uri_graphql` and `client_uri_ws`) with defaults and full CLI/environment variable support
 
 Changed:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,8 @@ The following table describes each configuration attribute available:
 | `backend`                              | string | `kedro_graphql.backends.mongodb.MongoBackend` | Python path to the backend class for data storage and retrieval.                                 |
 | `broker`                               | string | `redis://localhost` | URI for the message broker (e.g., Redis) used for task queueing.                                |
 | `celery_result_backend`                 | string | `redis://localhost` | URI for the Celery result backend (e.g., Redis).                                                 |
+| `client_uri_graphql`                   | string | `http://localhost:5000/graphql` | URI for GraphQL API endpoint used by the GraphQL client.                                         |
+| `client_uri_ws`                        | string | `ws://localhost:5000/graphql` | URI for WebSocket endpoint used by the GraphQL client for subscriptions.                         |
 | `conf_source`                          | string | `None` | Optional path to an alternative configuration source.                                             |
 | `deprecations_docs`                     | string | `""` | Optional URL to documentation about deprecated features.                                          |
 | `env`                                  | string | `local` | Environment name (e.g., "local").                                                                |
@@ -128,6 +130,8 @@ config:
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
+  client_uri_graphql: "http://localhost:5000/graphql"
+  client_uri_ws: "ws://localhost:5000/graphql"
   conf_source: null
   deprecations_docs: ""
   env: "local"
@@ -210,6 +214,8 @@ provide them as JSON strings.
 | backend                                            | --backend                                        | kedro_graphql.backends.mongodb.MongoBackend         |
 | broker                                             | --broker                                         | redis://localhost                                    |
 | celery_result_backend                              | --celery-result-backend                          | redis://localhost                                    |
+| client_uri_graphql                                 | --client-uri-graphql                             | http://localhost:5000/graphql                        |
+| client_uri_ws                                      | --client-uri-ws                                  | ws://localhost:5000/graphql                          |
 | conf_source                                        | --conf-source                                    | $HOME/myproject/conf                                 |
 | deprecations_docs                                  | --deprecations-docs                              | `https://github.com/myrepo/docs` (optional)         |
 | env                                                | --env                                            | local                                                |
@@ -290,6 +296,8 @@ Environment variables will take precedence over values defined in a `.env` file.
 
 ```bash
 KEDRO_GRAPHQL_MONGO_URI=mongodb://root:example@localhost:27017/
+KEDRO_GRAPHQL_CLIENT_URI_GRAPHQL=http://localhost:5000/graphql
+KEDRO_GRAPHQL_CLIENT_URI_WS=ws://localhost:5000/graphql
 KEDRO_GRAPHQL_APP_TITLE="My Custom Kedro GraphQL"
 KEDRO_GRAPHQL_BACKEND=kedro_graphql.backends.mongodb.MongoBackend
 ```

--- a/spec-api-auth.yaml
+++ b/spec-api-auth.yaml
@@ -6,6 +6,8 @@ config:
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
+  client_uri_graphql: "http://localhost:5000/graphql"
+  client_uri_ws: "ws://localhost:5000/graphql"
   conf_source: null
   deprecation_docs: ""
   env: "local"

--- a/spec-api.yaml
+++ b/spec-api.yaml
@@ -6,6 +6,8 @@ config:
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
+  client_uri_graphql: "http://localhost:5000/graphql"
+  client_uri_ws: "ws://localhost:5000/graphql"
   conf_source: null
   deprecation_docs: ""
   env: "local"

--- a/src/kedro_graphql/commands.py
+++ b/src/kedro_graphql/commands.py
@@ -50,6 +50,8 @@ def commands():
 @click.option("--backend", default=None, help="The only supported value for this option is 'kedro_graphql.backends.mongodb.MongoBackend'")
 @click.option("--broker", default=None, help="URI to broker e.g. 'redis://localhost'")
 @click.option("--celery-result-backend", default=None, help="URI to backend for celery results e.g. 'redis://localhost'")
+@click.option("--client-uri-graphql", default=None, help="URI for GraphQL API endpoint used by the GraphQL client")
+@click.option("--client-uri-ws", default=None, help="URI for WebSocket endpoint used by the GraphQL client for subscriptions")
 @click.option("--conf-source", default=None, help="Path of a directory where project configuration is stored.")
 @click.option("--deprecations-docs", default=None, help="URL to documentation about deprecated features")
 @click.option("--env", "-e", default=None, help="Kedro configuration environment name. Defaults to `local`.")
@@ -80,7 +82,7 @@ def commands():
 @click.option("--ui", "-u", is_flag=True, default=False, help="Start a viz app.")
 @click.option("--ui-spec", default="", help="UI YAML specification file")
 @click.option("--worker", "-w", is_flag=True, default=False, help="Start a celery worker.")
-def gql(metadata, app, app_title, app_description, backend, broker, celery_result_backend, conf_source,
+def gql(metadata, app, app_title, app_description, backend, broker, celery_result_backend, client_uri_graphql, client_uri_ws, conf_source,
         deprecations_docs, env, events_config, imports, local_file_provider_download_allowed_roots,
         local_file_provider_jwt_algorithm, local_file_provider_jwt_secret_key, local_file_provider_server_url,
         local_file_provider_upload_allowed_roots, local_file_provider_upload_max_file_size_mb,
@@ -106,6 +108,10 @@ def gql(metadata, app, app_title, app_description, backend, broker, celery_resul
         cli_config["KEDRO_GRAPHQL_BROKER"] = broker
     if celery_result_backend:
         cli_config["KEDRO_GRAPHQL_CELERY_RESULT_BACKEND"] = celery_result_backend
+    if client_uri_graphql:
+        cli_config["KEDRO_GRAPHQL_CLIENT_URI_GRAPHQL"] = client_uri_graphql
+    if client_uri_ws:
+        cli_config["KEDRO_GRAPHQL_CLIENT_URI_WS"] = client_uri_ws
     if conf_source:
         cli_config["KEDRO_GRAPHQL_CONF_SOURCE"] = conf_source
     if deprecations_docs:

--- a/src/kedro_graphql/config.py
+++ b/src/kedro_graphql/config.py
@@ -16,6 +16,8 @@ defaults = {
     "KEDRO_GRAPHQL_BACKEND": "kedro_graphql.backends.mongodb.MongoBackend",
     "KEDRO_GRAPHQL_BROKER": "redis://localhost",
     "KEDRO_GRAPHQL_CELERY_RESULT_BACKEND": "redis://localhost",
+    "KEDRO_GRAPHQL_CLIENT_URI_GRAPHQL": "http://localhost:5000/graphql",
+    "KEDRO_GRAPHQL_CLIENT_URI_WS": "ws://localhost:5000/graphql",
     "KEDRO_GRAPHQL_CONF_SOURCE": None,
     "KEDRO_GRAPHQL_DEPRECATIONS_DOCS": None,
     "KEDRO_GRAPHQL_ENV": "local",


### PR DESCRIPTION
Added:
- client URI configuration options for GraphQL client (`client_uri_graphql` and `client_uri_ws`) with defaults and full CLI/environment variable support