### PR TITLE
Feat/list partitions read datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+Added:
+
+- `DataSetInput.list_partitions` flag to support partition discovery in `readDatasets`
+- `readDatasets` schema coverage for partition discovery and partition-specific signed URL flows
+- Schema tests to cover baseline read datasets, list partitions, and partition-specific signed URL behavior
+- Documentation updates for partitioned datasets with a clear two-step flow (discover partitions, then request signed URLs)
+
+Changed:
+
+- `read_datasets` now supports returning `DataSet` for partition discovery requests
+
+Fixed:
+
+- Mismatch in types `ObjectId` and `str` caused the `readTemplates` query to always fail
+- Celery task callback null-safety in `before_start`, `on_success`, and `on_retry` when pipeline records are missing
+- `after_return` temp log cleanup logging bug (`.name` used on string path)
+
 
 ## [1.5.1] - 2026-03-31
 

--- a/docs/extend_signed_url_provider.md
+++ b/docs/extend_signed_url_provider.md
@@ -66,6 +66,190 @@ config:
 
 The API will use the configured provider to generate signed URLs for dataset operations.
 
+### GraphQL Examples: `readDatasets` and `createDatasets`
+
+Both `readDatasets` (query) and `createDatasets` (mutation) return one signed-url object per dataset input. For non-partitioned datasets you get a `SignedUrl`. For partitioned datasets you get a `SignedUrls` wrapper containing an array.
+
+#### `readDatasets` query
+
+```graphql
+query ReadDatasets($id: String!, $datasets: [DataSetInput!]!, $expires_in_sec: Int!) {
+  readDatasets(id: $id, datasets: $datasets, expiresInSec: $expires_in_sec) {
+    __typename
+    ... on SignedUrl {
+      url
+      file
+      fields {
+        name
+        value
+      }
+    }
+    ... on SignedUrls {
+      urls {
+        url
+        file
+        fields {
+          name
+          value
+        }
+      }
+    }
+    ... on DataSet {
+      name
+      partitions
+    }
+  }
+}
+```
+
+Example variables (single dataset):
+
+```json
+{
+  "id": "PIPELINE_ID",
+  "datasets": [{ "name": "text_in" }],
+  "expires_in_sec": 3600
+}
+```
+
+Example response shape (local-file provider):
+
+```json
+{
+  "data": {
+    "readDatasets": [
+      {
+        "__typename": "SignedUrl",
+        "url": "http://localhost:5000/download?token=...",
+        "file": "text_in.txt",
+        "fields": [{ "name": "token", "value": "JWT_TOKEN" }]
+      }
+    ]
+  }
+}
+```
+
+Partitioned datasets use a two-step flow:
+
+1. Discover available partition keys.
+2. Request signed URLs for the partition keys you want to read.
+
+Step 1: discover partition keys
+
+```json
+{
+  "id": "PIPELINE_ID",
+  "datasets": [
+    {
+      "name": "my_partitioned_dataset",
+      "list_partitions": true
+    }
+  ],
+  "expires_in_sec": 3600
+}
+```
+
+Expected response shape for partition discovery:
+
+```json
+{
+  "data": {
+    "readDatasets": [
+      {
+        "__typename": "DataSet",
+        "name": "my_partitioned_dataset",
+        "partitions": [
+          "2026-05-01",
+          "2026-05-02"
+        ]
+      }
+    ]
+  }
+}
+```
+
+Step 2: request signed URLs for selected partitions
+
+```json
+{
+  "id": "PIPELINE_ID",
+  "datasets": [
+    {
+      "name": "my_partitioned_dataset",
+      "partitions": ["part-1", "part-2"]
+    }
+  ],
+  "expires_in_sec": 3600
+}
+```
+
+!!! Note
+
+    Do not combine `listPartitions` and `partitions` in the same dataset input. If both are provided, `listPartitions` takes precedence and returns partition metadata (`DataSet`) instead of signed URLs.
+
+
+#### `createDatasets` mutation
+
+```graphql
+mutation CreateDatasets(
+  $id: String!
+  $datasets: [DataSetInput!]!
+  $expires_in_sec: Int!
+) {
+  createDatasets(id: $id, datasets: $datasets, expiresInSec: $expires_in_sec) {
+    __typename
+    ... on SignedUrl {
+      url
+      file
+      fields {
+        name
+        value
+      }
+    }
+    ... on SignedUrls {
+      urls {
+        url
+        file
+        fields {
+          name
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+Example variables (create/upload signed URLs for datasets):
+
+```json
+{
+  "id": "PIPELINE_ID",
+  "datasets": [{ "name": "text_out" }],
+  "expires_in_sec": 3600
+}
+```
+
+Example response shape (local-file provider):
+
+```json
+{
+  "data": {
+    "createDatasets": [
+      {
+        "__typename": "SignedUrl",
+        "url": "http://localhost:5000/upload",
+        "file": "text_out.txt",
+        "fields": [{ "name": "token", "value": "JWT_TOKEN" }]
+      }
+    ]
+  }
+}
+```
+Use `SignedUrl.url` as the upload endpoint and submit `SignedUrl.fields` as the required form fields (along with the file payload).
+
+If the underlying dataset type is a `partitions.PartitionedDataset`, `createDatasets` requires `partitions` to be provided inside each `DataSetInput`.
+
 ### Additional Configuration
 
 You can further customize the behavior of signed URL providers using the following configuration attributes:

--- a/src/kedro_graphql/client.py
+++ b/src/kedro_graphql/client.py
@@ -225,11 +225,11 @@ class KedroGraphqlClient():
         """Read a dataset.
         Kwargs:
             id (str): pipeline id
-            datasets (list[DataSetInput]): dataset inputs for which to get signed URLs. In order to read specific partitions of a PartitionedDataset, pass a DataSetInput with the dataset name and list of partitions e.g. DataSetInput(name="dataset_name", partitions=["partition1", "partition2"]).
+            datasets (list[DataSetInput]): dataset inputs for which to get signed URLs. In order to read specific partitions of a PartitionedDataset, pass a DataSetInput with the dataset name and list of partitions e.g. DataSetInput(name="dataset_name", partitions=["partition1", "partition2"]). To list available partitions, pass DataSetInput(name="dataset_name", list_partitions=True).
             expires_in_sec (int): number of seconds the signed URL should be valid for
 
         Returns:
-            str: signed URL for reading the dataset
+            [SignedUrl | SignedUrls | dict]: signed URL objects, or DataSet dictionaries when list_partitions is requested
         """
         query = """
             query readDatasets($id: String!, $datasets: [DataSetInput!]!, $expires_in_sec: Int!) {
@@ -253,6 +253,15 @@ class KedroGraphqlClient():
                     }
                   }
                 }
+                ... on DataSet {
+                  name
+                  config
+                  tags {
+                    key
+                    value
+                  }
+                  partitions
+                }
               }
             }
         """
@@ -266,6 +275,9 @@ class KedroGraphqlClient():
             elif d["__typename"] == "SignedUrls":
                 d.pop("__typename")
                 urls.append(SignedUrls.decode(d, decoder="graphql"))
+            elif d["__typename"] == "DataSet":
+                d.pop("__typename")
+                urls.append(d)
             else:
                 raise TypeError(
                     f"Unexpected type {d['__typename']} returned from readDatasets")

--- a/src/kedro_graphql/models.py
+++ b/src/kedro_graphql/models.py
@@ -302,6 +302,7 @@ class DataSetInput:
     config: Optional[str] = None
     tags: Optional[List[TagInput]] = None
     partitions: Optional[List[str]] = None
+    list_partitions: Optional[bool] = None
 
     def encode(self, encoder="graphql"):
         if encoder == "dict":

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -323,10 +323,11 @@ class Query:
     @strawberry.field(description="Get a pipeline template.", extensions=[PermissionExtension(permissions=[PERMISSIONS_CLASS(action="read_pipeline_template")])])
     def pipeline_template(self, info: Info, id: str) -> PipelineTemplate:
         for p in info.context["request"].app.kedro_pipelines_index:
-            if p.id == id:
+            if str(p.id) == id:
                 logger.info(
                     f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=read_pipeline_template, id={id}")
                 return p
+        raise InvalidPipeline(f"Pipeline {id} does not exist in the project.")
 
     @strawberry.field(description="Get a list of pipeline templates.", extensions=[PermissionExtension(permissions=[PERMISSIONS_CLASS(action="read_pipeline_templates")])])
     def pipeline_templates(self, info: Info, limit: int, cursor: Optional[str] = None) -> PipelineTemplates:

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -30,6 +30,7 @@ from .pipeline_event_monitor import PipelineEventMonitor
 from .hooks import InvalidPipeline
 from .logs.logger import PipelineLogStream, logger
 from .models import (
+    DataSet,
     DataSetInput,
     PageMeta,
     Pipeline,
@@ -43,7 +44,6 @@ from .models import (
     SignedUrl,
     SignedUrls,
     State,
-    DataSetInput
 )
 from .tasks import run_pipeline
 from .permissions import get_permissions
@@ -405,17 +405,17 @@ class Query:
         )
 
     @strawberry.field(description="Read a dataset with a signed URL", extensions=[PermissionExtension(permissions=[PERMISSIONS_CLASS(action="read_dataset")])])
-    async def read_datasets(self, id: str, info: Info, datasets: List[DataSetInput], expires_in_sec: int = CONFIG["KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC"]) -> List[SignedUrl | SignedUrls | None]:
+    async def read_datasets(self, id: str, info: Info, datasets: List[DataSetInput], expires_in_sec: int = CONFIG["KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC"]) -> List[SignedUrl | SignedUrls | DataSet | None]:
         """
         Get a signed URL for downloading a dataset.
 
         Args:
             id (str): The ID of the pipeline.
             info (Info): The GraphQL execution context.
-            datasets (List[DataSetInput]): The datasets to get signed URLs for. In order to read specific partitions of a PartitionedDataset, pass a DataSetInput with the dataset name and list of partitions e.g. DataSetInput(name="dataset_name", partitions=["partition1", "partition2"]).
+            datasets (List[DataSetInput]): The datasets to read. In order to read specific partitions of a PartitionedDataset, pass a DataSetInput with the dataset name and list of partitions e.g. DataSetInput(name="dataset_name", partitions=["partition1", "partition2"]). To discover available partitions for a dataset, pass list_partitions=True.
             expires_in_sec (int): The number of seconds the signed URL should be valid for.
         Returns:
-            List[SignedUrl | SignedUrls | None]: An array of signed URLs for downloading the dataset or None if not applicable.
+            List[SignedUrl | SignedUrls | DataSet | None]: An array containing signed URLs, DataSet objects for partition discovery, or None if not applicable.
 
         Raises:
             ValueError: If expires_in_sec is greater than max expires_in_sec
@@ -439,6 +439,12 @@ class Query:
                 logger.warning(
                     f"Dataset '{d.name}' not found in the data catalog of pipeline_name={p.name} pipeline_id={p.id}. SignedURL set to None.")
                 urls.append(None)
+                continue
+
+            if d.list_partitions:
+                logger.info(
+                    f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=list_partitions, dataset={dataset.name}")
+                urls.append(dataset)
                 continue
 
             module_path, class_name = CONFIG["KEDRO_GRAPHQL_SIGNED_URL_PROVIDER"].rsplit(

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -65,6 +65,10 @@ class KedroGraphqlTask(Task):
             task_id, broker_url=self._app.conf["broker_url"])
         logging.getLogger("kedro").addHandler(handler)
         p = self.db.read(id=kwargs["id"])
+        if p is None:
+            logger.error(
+                f"Pipeline id={kwargs['id']} not found in backend during before_start; task_id={task_id}")
+            return
         p.status[-1].state = State.STARTED
         p.status[-1].task_id = task_id
         p.status[-1].task_args = json.dumps(args)
@@ -151,8 +155,9 @@ class KedroGraphqlTask(Task):
         """
 
         p = self.db.read(id=kwargs["id"])
-        p.status[-1].state = State.SUCCESS
-        self.db.update(p)
+        if p is not None:
+            p.status[-1].state = State.SUCCESS
+            self.db.update(p)
 
     def on_retry(self, exc, task_id, args, kwargs, einfo):
         """Retry handler.
@@ -171,10 +176,11 @@ class KedroGraphqlTask(Task):
         """
 
         p = self.db.read(id=kwargs["id"])
-        p.status[-1].state = State.RETRY
-        p.status[-1].task_exception = str(exc)
-        p.status[-1].task_einfo = str(einfo)
-        self.db.update(p)
+        if p is not None:
+            p.status[-1].state = State.RETRY
+            p.status[-1].task_exception = str(exc)
+            p.status[-1].task_einfo = str(einfo)
+            self.db.update(p)
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Error handler.
@@ -245,7 +251,7 @@ class KedroGraphqlTask(Task):
             # logger.info(
             #    f"Failed to clear logs in {os.path.join(CONFIG['KEDRO_GRAPHQL_LOG_TMP_DIR'].name, task_id)}: {e}")
             logger.info(
-                f"Failed to clear logs in {os.path.join(self.gql_config['KEDRO_GRAPHQL_LOG_TMP_DIR'].name, task_id)}: {e}")
+                f"Failed to clear logs in {os.path.join(self.gql_config['KEDRO_GRAPHQL_LOG_TMP_DIR'], task_id)}: {e}")
 
 
 @shared_task(bind=True, base=KedroGraphqlTask)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -374,13 +374,22 @@ def mock_pipeline_no_task(mock_app, mock_text_in, mock_text_out):
 
 
 @pytest.fixture
-def mock_example01(mock_app):
+def mock_timestamped_partitioned_dir(tmp_path):
+    partitioned_dir = tmp_path / "timestamped_partitioned"
+    partitioned_dir.mkdir(parents=True, exist_ok=True)
+    (partitioned_dir / "part_00.txt").write_text("part 00")
+    (partitioned_dir / "part_01.txt").write_text("part 01")
+    return partitioned_dir
+
+
+@pytest.fixture
+def mock_example01(mock_app, mock_timestamped_partitioned_dir, mock_text_in):
 
     inputs = [{"name": "text_in", "config": json.dumps(
-        {"type": "text.TextDataset", "filepath": "./data/01_raw/text_in.txt"})}]
+        {"type": "text.TextDataset", "filepath": str(mock_text_in)})}]
     outputs = [{"name": "timestamped_partitioned", "config": json.dumps(
         {"type": "partitions.PartitionedDataset",
-         "path": "./data/02_intermediate/timestamped_partitioned",
+         "path": str(mock_timestamped_partitioned_dir),
          "filename_suffix": ".txt",
          "dataset": {"type": "text.TextDataset"}})}]
     parameters = [{"name": "example", "value": "hello"}]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -373,6 +373,37 @@ def mock_pipeline_no_task(mock_app, mock_text_in, mock_text_out):
     return p
 
 
+@pytest.fixture
+def mock_example01(mock_app):
+
+    inputs = [{"name": "text_in", "config": json.dumps(
+        {"type": "text.TextDataset", "filepath": "./data/01_raw/text_in.txt"})}]
+    outputs = [{"name": "timestamped_partitioned", "config": json.dumps(
+        {"type": "partitions.PartitionedDataset",
+         "path": "./data/02_intermediate/timestamped_partitioned",
+         "filename_suffix": ".txt",
+         "dataset": {"type": "text.TextDataset"}})}]
+    parameters = [{"name": "example", "value": "hello"}]
+    tags = [{"key": "author", "value": "harinlee83"}, {
+        "key": "package", "value": "kedro-graphql"}]
+
+    p = Pipeline(
+        name="example01",
+        data_catalog=[DataSet(**i) for i in inputs] + [DataSet(**o) for o in outputs],
+        parameters=[Parameter(**p) for p in parameters],
+        tags=[Tag(**p) for p in tags],
+        status=[PipelineStatus(state=State.STAGED,
+                               runner=mock_app.config["KEDRO_GRAPHQL_RUNNER"],
+                               session=mock_app.kedro_session.session_id,
+                               started_at=datetime.now(),
+                               task_name=str(run_pipeline))]
+    )
+
+    p.created_at = datetime.now()
+    p = mock_app.backend.create(p)
+    return p
+
+
 @pytest.fixture(autouse=True)
 def delete_pipeline_collection(mock_app):
     # Will be executed before the first test

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -159,6 +159,38 @@ class TestKedroGraphqlClient:
         assert isinstance(r[0], SignedUrl)
 
     @pytest.mark.asyncio
+    async def test_read_datasets_list_partitions(self, mock_client):
+        async def _mock_execute_query(*args, **kwargs):
+            return {
+                "readDatasets": [
+                    {
+                        "__typename": "DataSet",
+                        "name": "my_partitioned_dataset",
+                        "config": json.dumps({
+                            "type": "partitions.PartitionedDataset",
+                            "path": "/tmp/my-bucket/path/to/partitioned_dataset",
+                            "filename_suffix": ".txt",
+                            "dataset": {"type": "text.TextDataset"}
+                        }),
+                        "tags": None,
+                        "partitions": ["part-0001", "part-0002"]
+                    }
+                ]
+            }
+
+        mock_client.execute_query = _mock_execute_query
+        r = await mock_client.read_datasets(
+            id="test-id",
+            datasets=[DataSetInput(name="my_partitioned_dataset", list_partitions=True)],
+            expires_in_sec=3600,
+        )
+        assert isinstance(r, list)
+        assert len(r) == 1
+        assert isinstance(r[0], dict)
+        assert r[0]["name"] == "my_partitioned_dataset"
+        assert r[0]["partitions"] == ["part-0001", "part-0002"]
+
+    @pytest.mark.asyncio
     async def test_create_datasets(self, mock_create_pipeline_staged, mock_client):
 
         pipeline_input, expected, pipeline = mock_create_pipeline_staged

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -328,3 +328,14 @@ class TestDataSetInput:
         assert isinstance(result, dict)
         assert result["name"] == dataset.name
         assert result["config"] == dataset.config
+
+    def test_encode_list_partitions(self):
+        dataset = DataSetInput(
+            name="my_partitioned_dataset",
+            list_partitions=True
+        )
+
+        result = dataset.encode(encoder="graphql")
+        assert isinstance(result, dict)
+        assert result["name"] == dataset.name
+        assert result["listPartitions"] is True

--- a/src/tests/test_schema_query.py
+++ b/src/tests/test_schema_query.py
@@ -71,12 +71,45 @@ class TestSchemaQuery:
         assert resp.errors is None
 
     @pytest.mark.asyncio
+    async def test_pipeline_template(self, mock_app, mock_info_context):
+        list_query = """
+        query TestQuery($limit: Int!) {
+          pipelineTemplates(limit: $limit) {
+            pipelineTemplates {
+              id
+              name
+            }
+          }
+        }
+        """
+        list_resp = await mock_app.schema.execute(list_query, variable_values={"limit": 1})
+        assert list_resp.errors is None
+        template = list_resp.data["pipelineTemplates"]["pipelineTemplates"][0]
+
+        query = """
+        query TestQuery($id: String!) {
+          pipelineTemplate(id: $id) {
+            id
+            name
+          }
+        }
+        """
+        resp = await mock_app.schema.execute(query, variable_values={"id": template["id"]})
+        assert resp.errors is None
+        assert resp.data["pipelineTemplate"]["id"] == template["id"]
+        assert resp.data["pipelineTemplate"]["name"] == template["name"]
+
+    @pytest.mark.asyncio
     async def test_read_datasets(self, mock_app, mock_info_context, mock_pipeline):
 
         query = """
         query TestQuery($id: String!, $datasets: [DataSetInput!]!, $expires_in_sec: Int!) {
           readDatasets(id: $id, datasets: $datasets, expiresInSec: $expires_in_sec){
             __typename
+            ... on DataSet {
+              name
+              partitions
+            }
             ... on SignedUrl {
               url
               file
@@ -98,10 +131,90 @@ class TestSchemaQuery:
           }
         }
         """
-        resp = await mock_app.schema.execute(query, variable_values={"id": str(mock_pipeline.id), "datasets": [{"name": "text_in"}, {"name": "text_out"}], "expires_in_sec": 3600})
+        resp = await mock_app.schema.execute(
+            query,
+            variable_values={
+                "id": str(mock_pipeline.id),
+                "datasets": [
+                    {"name": "text_in"},
+                    {"name": "text_out"}
+                ],
+                "expires_in_sec": 3600
+            }
+        )
         assert resp.data["readDatasets"] is not None
         assert len(resp.data["readDatasets"]) == 2
+        assert resp.data["readDatasets"][0]["__typename"] == "SignedUrl"
         assert resp.data["readDatasets"][0].get("url", False)
         assert resp.data["readDatasets"][0].get("fields", False)
         assert resp.data["readDatasets"][0].get("file", False)
+        assert resp.data["readDatasets"][1]["__typename"] == "SignedUrl"
+        assert resp.errors is None
+
+    @pytest.mark.asyncio
+    async def test_read_datasets_list_partitions(self, mock_app, mock_info_context, mock_example01):
+
+        query = """
+        query TestQuery($id: String!, $datasets: [DataSetInput!]!, $expires_in_sec: Int!) {
+          readDatasets(id: $id, datasets: $datasets, expiresInSec: $expires_in_sec){
+            __typename
+            ... on DataSet {
+              name
+              partitions
+            }
+          }
+        }
+        """
+        resp = await mock_app.schema.execute(
+            query,
+            variable_values={
+                "id": str(mock_example01.id),
+                "datasets": [
+                    {"name": "timestamped_partitioned", "listPartitions": True}
+                ],
+                "expires_in_sec": 3600
+            }
+        )
+        assert resp.data["readDatasets"] is not None
+        assert len(resp.data["readDatasets"]) == 1
+        assert resp.data["readDatasets"][0]["__typename"] == "DataSet"
+        assert resp.data["readDatasets"][0]["name"] == "timestamped_partitioned"
+        assert isinstance(resp.data["readDatasets"][0]["partitions"], list)
+        assert resp.errors is None
+
+    @pytest.mark.asyncio
+    async def test_read_datasets_partitions(self, mock_app, mock_info_context, mock_example01):
+
+        query = """
+        query TestQuery($id: String!, $datasets: [DataSetInput!]!, $expires_in_sec: Int!) {
+          readDatasets(id: $id, datasets: $datasets, expiresInSec: $expires_in_sec){
+            __typename
+            ... on SignedUrls {
+              urls {
+                url
+                file
+                fields {
+                  name
+                  value
+                }
+              }
+            }
+          }
+        }
+        """
+        resp = await mock_app.schema.execute(
+            query,
+            variable_values={
+                "id": str(mock_example01.id),
+                "datasets": [
+                    {"name": "timestamped_partitioned", "partitions": ["part_00"]}
+                ],
+                "expires_in_sec": 3600
+            }
+        )
+        assert resp.data["readDatasets"] is not None
+        assert len(resp.data["readDatasets"]) == 1
+        assert resp.data["readDatasets"][0]["__typename"] == "SignedUrls"
+        assert isinstance(resp.data["readDatasets"][0]["urls"], list)
+        assert len(resp.data["readDatasets"][0]["urls"]) == 1
         assert resp.errors is None


### PR DESCRIPTION
Added:

- `DataSetInput.list_partitions` flag to support partition discovery in `readDatasets`
- `readDatasets` schema coverage for partition discovery and partition-specific signed URL flows
- Schema tests to cover baseline read datasets, list partitions, and partition-specific signed URL behavior
- Documentation updates for partitioned datasets with a clear two-step flow (discover partitions, then request signed URLs)

Changed:

- `read_datasets` now supports returning `DataSet` for partition discovery requests

Fixed:

- Mismatch in types `ObjectId` and `str` caused the `readTemplates` query to always fail
- Celery task callback null-safety in `before_start`, `on_success`, and `on_retry` when pipeline records are missing
- `after_return` temp log cleanup logging bug (`.name` used on string path)