### PR TITLE
Feat/support aborting pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,28 @@ Added:
 - `readDatasets` schema coverage for partition discovery and partition-specific signed URL flows
 - Schema tests to cover baseline read datasets, list partitions, and partition-specific signed URL behavior
 - Documentation updates for partitioned datasets with a clear two-step flow (discover partitions, then request signed URLs)
+- `ABORTED` to both `PipelineInputStatus` and pipeline `State` enums so clients can request and observe pipeline aborts through GraphQL
+- `ABORTING` pipeline state and `abort_requested_at` / `abort_completed_at` timestamps on `PipelineStatus` for explicit abort lifecycle tracking
+- `KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL` (default `15`) for controlling abort check frequency in Celery task execution (values below `1` second are clamped at runtime)
+- `KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD` (default `60`) for controlling how long the worker waits before escalating abort signals (values below `5` seconds are clamped at runtime)
+- CLI flags `--celery-abort-polling-interval` and `--celery-abort-grace-period` on `kedro gql` to override the above settings
+- Schema mutation tests for aborting a running pipeline and rejecting abort requests for non-running pipelines
 
 Changed:
 
 - `read_datasets` now supports returning `DataSet` for partition discovery requests
+- `KedroGraphqlTask` now inherits from Celery `AbortableTask`
+- `run_pipeline` now executes the Kedro runner in a child subprocess while the parent task monitors abort status and sends OS signals (`SIGINT` first, then escalation)
+- `updatePipeline` now handles `state: ABORTED` by calling `AbortableAsyncResult.abort()` and persisting `ABORTING` in the document backend until worker-side abort completion; repeated abort requests while already `ABORTING` or `ABORTED` return without error
+- Task `on_success` and `on_failure` handlers now preserve abort states and avoid overwriting `ABORTING`/`ABORTED` with `SUCCESS` or `FAILURE`
 
 Fixed:
 
 - Mismatch in types `ObjectId` and `str` caused the `readTemplates` query to always fail
 - Celery task callback null-safety in `before_start`, `on_success`, and `on_retry` when pipeline records are missing
 - `after_return` temp log cleanup logging bug (`.name` used on string path)
-
+- Kedro log handlers added during pipeline runs are now removed from the `kedro` logger (not the task module logger), tagged per Celery task id, reducing duplicate log output and teardown noise
+- Pipeline `State` enum typo corrected from `RECIEVED` to `RECEIVED`
 
 ## [1.5.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Added:
 - Documentation updates for partitioned datasets with a clear two-step flow (discover partitions, then request signed URLs)
 - `ABORTED` to both `PipelineInputStatus` and pipeline `State` enums so clients can request and observe pipeline aborts through GraphQL
 - `ABORTING` pipeline state and `abort_requested_at` / `abort_completed_at` timestamps on `PipelineStatus` for explicit abort lifecycle tracking
-- `KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL` (default `15`) for controlling abort check frequency in Celery task execution (values below `1` second are clamped at runtime)
+- `KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL` (default `5`) for controlling abort check frequency in Celery task execution (values below `1` second are clamped at runtime)
 - `KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD` (default `60`) for controlling how long the worker waits before escalating abort signals (values below `5` seconds are clamped at runtime)
 - CLI flags `--celery-abort-polling-interval` and `--celery-abort-grace-period` on `kedro gql` to override the above settings
 - Schema mutation tests for aborting a running pipeline and rejecting abort requests for non-running pipelines

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,8 @@ The following table describes each configuration attribute available:
 | `backend`                              | string | `kedro_graphql.backends.mongodb.MongoBackend` | Python path to the backend class for data storage and retrieval.                                 |
 | `broker`                               | string | `redis://localhost` | URI for the message broker (e.g., Redis) used for task queueing.                                |
 | `celery_result_backend`                 | string | `redis://localhost` | URI for the Celery result backend (e.g., Redis).                                                 |
+| `celery_abort_polling_interval`         | float | `5` | Polling interval in seconds used by abortable Celery tasks to check whether a running pipeline should be interrupted. Minimum value is `1` second (values below are clamped to `1`). |
+| `celery_abort_grace_period`             | float | `60` | Grace period in seconds before escalating task abort signals (`SIGINT` -> `SIGTERM` -> `SIGKILL`). Minimum value is `5` seconds (values below are clamped to `5`). |
 | `client_uri_graphql`                   | string | `http://localhost:5000/graphql` | URI for GraphQL API endpoint used by the GraphQL client.                                         |
 | `client_uri_ws`                        | string | `ws://localhost:5000/graphql` | URI for WebSocket endpoint used by the GraphQL client for subscriptions.                         |
 | `conf_source`                          | string | `None` | Optional path to an alternative configuration source.                                             |
@@ -131,6 +133,8 @@ config:
   backend: "kedro_graphql.backends.mongodb.MongoBackend"
   broker: "redis://localhost"
   celery_result_backend: "redis://localhost"
+  celery_abort_polling_interval: 5
+  celery_abort_grace_period: 60
   client_uri_graphql: "http://localhost:5000/graphql"
   client_uri_ws: "ws://localhost:5000/graphql"
   conf_source: null
@@ -217,6 +221,8 @@ provide them as JSON strings.
 | backend                                            | --backend                                        | kedro_graphql.backends.mongodb.MongoBackend         |
 | broker                                             | --broker                                         | redis://localhost                                    |
 | celery_result_backend                              | --celery-result-backend                          | redis://localhost                                    |
+| celery_abort_polling_interval                      | --celery-abort-polling-interval                  | 5                                                    |
+| celery_abort_grace_period                          | --celery-abort-grace-period                      | 60                                                   |
 | client_uri_graphql                                 | --client-uri-graphql                             | http://localhost:5000/graphql                        |
 | client_uri_ws                                      | --client-uri-ws                                  | ws://localhost:5000/graphql                          |
 | conf_source                                        | --conf-source                                    | $HOME/myproject/conf                                 |
@@ -301,6 +307,8 @@ Environment variables will take precedence over values defined in a `.env` file.
 KEDRO_GRAPHQL_MONGO_URI=mongodb://root:example@localhost:27017/
 KEDRO_GRAPHQL_CLIENT_URI_GRAPHQL=http://localhost:5000/graphql
 KEDRO_GRAPHQL_CLIENT_URI_WS=ws://localhost:5000/graphql
+KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL=5
+KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD=60
 KEDRO_GRAPHQL_APP_TITLE="My Custom Kedro GraphQL"
 KEDRO_GRAPHQL_BACKEND=kedro_graphql.backends.mongodb.MongoBackend
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -351,6 +351,42 @@ mutation MyMutation {
 }
 ```
 
+### Aborting a pipeline
+
+To abort an in-flight pipeline, call `updatePipeline` with `state: ABORTED`.
+The running Celery task checks abort status in a small polling loop and runs the Kedro
+execution in a child subprocess. When abort is requested, the parent task sends `SIGINT`
+first (for graceful interruption), then escalates to stronger signals if needed.
+After the mutation, pipeline state is set to `ABORTING` until the worker confirms the
+child process has stopped, then it transitions to `ABORTED`.
+
+```graphql
+mutation MyMutation {
+  updatePipeline(
+    id: "67b8b41535ac10b558916cba"
+    pipeline: {name: "example00", state: ABORTED}
+  ) {
+    id
+    status {
+      state
+      taskId
+    }
+  }
+}
+```
+
+You can tune how quickly abort requests are observed via:
+
+```bash
+export KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL=5
+```
+
+And tune how long each graceful shutdown phase waits before escalation:
+
+```bash
+export KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD=60
+```
+
 ### Search for a pipeline
 
 Search for a pipeline using the [MongoDB document query filter](https://www.mongodb.com/docs/manual/core/document/#std-label-document-query-filter), [MongoDB cursor sort sytnax](https://www.mongodb.com/docs/manual/reference/method/cursor.sort/#syntax), and the [MongoDB cursor limit](https://www.mongodb.com/docs/manual/reference/method/cursor.limit/#cursor.limit--) in the `readPipelines` query. Executing the following query below will return up to **10 pipelines** that have a tag key of `"owner"` with a tag value of `"harinlee83"`, sorted chronologically in **descending order**.

--- a/src/kedro_graphql/commands.py
+++ b/src/kedro_graphql/commands.py
@@ -49,6 +49,8 @@ def commands():
 @click.option("--backend", default=None, help="The only supported value for this option is 'kedro_graphql.backends.mongodb.MongoBackend'")
 @click.option("--broker", default=None, help="URI to broker e.g. 'redis://localhost'")
 @click.option("--celery-result-backend", default=None, help="URI to backend for celery results e.g. 'redis://localhost'")
+@click.option("--celery-abort-polling-interval", default=None, type=float, help="Polling interval in seconds for checking abort status while a pipeline subprocess is running")
+@click.option("--celery-abort-grace-period", default=None, type=float, help="Grace period in seconds before escalating abort signals from SIGINT to SIGTERM/SIGKILL")
 @click.option("--client-uri-graphql", default=None, help="URI for GraphQL API endpoint used by the GraphQL client")
 @click.option("--client-uri-ws", default=None, help="URI for WebSocket endpoint used by the GraphQL client for subscriptions")
 @click.option("--conf-source", default=None, help="Path of a directory where project configuration is stored.")
@@ -83,7 +85,7 @@ def commands():
 @click.option("--ui", "-u", is_flag=True, default=False, help="Start a viz app.")
 @click.option("--ui-spec", default="", help="UI YAML specification file")
 @click.option("--worker", "-w", is_flag=True, default=False, help="Start a celery worker.")
-def gql(metadata, app, app_title, app_description, backend, broker, celery_result_backend, client_uri_graphql, client_uri_ws, conf_source,
+def gql(metadata, app, app_title, app_description, backend, broker, celery_result_backend, celery_abort_polling_interval, celery_abort_grace_period, client_uri_graphql, client_uri_ws, conf_source,
         dataset_filepath_masks, dataset_filepath_allowed_roots, deprecations_docs, env, events_config, imports,
         local_file_provider_download_allowed_roots,
         local_file_provider_jwt_algorithm, local_file_provider_jwt_secret_key, local_file_provider_server_url,
@@ -109,6 +111,10 @@ def gql(metadata, app, app_title, app_description, backend, broker, celery_resul
         cli_config["KEDRO_GRAPHQL_BROKER"] = broker
     if celery_result_backend:
         cli_config["KEDRO_GRAPHQL_CELERY_RESULT_BACKEND"] = celery_result_backend
+    if celery_abort_polling_interval is not None:
+        cli_config["KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL"] = celery_abort_polling_interval
+    if celery_abort_grace_period is not None:
+        cli_config["KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD"] = celery_abort_grace_period
     if client_uri_graphql:
         cli_config["KEDRO_GRAPHQL_CLIENT_URI_GRAPHQL"] = client_uri_graphql
     if client_uri_ws:

--- a/src/kedro_graphql/config.py
+++ b/src/kedro_graphql/config.py
@@ -16,6 +16,8 @@ defaults = {
     "KEDRO_GRAPHQL_BACKEND": "kedro_graphql.backends.mongodb.MongoBackend",
     "KEDRO_GRAPHQL_BROKER": "redis://localhost",
     "KEDRO_GRAPHQL_CELERY_RESULT_BACKEND": "redis://localhost",
+    "KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL": 15,
+    "KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD": 60,
     "KEDRO_GRAPHQL_CLIENT_URI_GRAPHQL": "http://localhost:5000/graphql",
     "KEDRO_GRAPHQL_CLIENT_URI_WS": "ws://localhost:5000/graphql",
     "KEDRO_GRAPHQL_CONF_SOURCE": None,

--- a/src/kedro_graphql/config.py
+++ b/src/kedro_graphql/config.py
@@ -16,7 +16,7 @@ defaults = {
     "KEDRO_GRAPHQL_BACKEND": "kedro_graphql.backends.mongodb.MongoBackend",
     "KEDRO_GRAPHQL_BROKER": "redis://localhost",
     "KEDRO_GRAPHQL_CELERY_RESULT_BACKEND": "redis://localhost",
-    "KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL": 15,
+    "KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL": 5,
     "KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD": 60,
     "KEDRO_GRAPHQL_CLIENT_URI_GRAPHQL": "http://localhost:5000/graphql",
     "KEDRO_GRAPHQL_CLIENT_URI_WS": "ws://localhost:5000/graphql",

--- a/src/kedro_graphql/models.py
+++ b/src/kedro_graphql/models.py
@@ -467,6 +467,7 @@ class PipelineSlice:
 class PipelineInputStatus(Enum):
     STAGED = "STAGED"
     READY = "READY"
+    ABORTED = "ABORTED"
 
 
 @strawberry.input(description="PipelineInput")
@@ -591,12 +592,14 @@ class State(Enum):
     READY = 'READY'
     STAGED = 'STAGED'
     STARTED = 'STARTED'
+    ABORTING = 'ABORTING'
+    ABORTED = 'ABORTED'
     RETRY = 'RETRY'
     FAILURE = 'FAILURE'
     SUCCESS = 'SUCCESS'
     REVOKED = 'REVOKED'
     PENDING = 'PENDING'
-    RECIEVED = 'RECIEVED'
+    RECEIVED = 'RECEIVED'
 
 
 @strawberry.type
@@ -607,6 +610,8 @@ class PipelineStatus:
     filtered_nodes: Optional[List[str]] = None
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
+    abort_requested_at: Optional[datetime] = None
+    abort_completed_at: Optional[datetime] = None
     task_id: Optional[str] = None
     task_name: Optional[str] = None
     task_args: Optional[str] = None
@@ -723,6 +728,10 @@ class Pipeline:
                     s["started_at"]) if s.get("started_at") else None,
                 finished_at=datetime.fromisoformat(
                     s["finished_at"]) if s.get("finished_at") else None,
+                abort_requested_at=datetime.fromisoformat(
+                    s["abort_requested_at"]) if s.get("abort_requested_at") else None,
+                abort_completed_at=datetime.fromisoformat(
+                    s["abort_completed_at"]) if s.get("abort_completed_at") else None,
                 task_name=s.get("task_name"),
                 task_id=s.get("task_id"),
                 task_args=s.get("task_args"),

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -9,6 +9,7 @@ from graphql.execution import ExecutionContext as GraphQLExecutionContext
 
 import strawberry
 from bson.objectid import ObjectId
+from celery.contrib.abortable import AbortableAsyncResult
 from celery.states import UNREADY_STATES, READY_STATES
 from fastapi.encoders import jsonable_encoder
 from kedro.framework.project import pipelines
@@ -566,6 +567,31 @@ class Mutation:
             raise InvalidPipeline(f"Error retrieving pipeline {id}: {e}")
 
         pipeline_input_dict = jsonable_encoder(pipeline)
+        requested_state = pipeline_input_dict.get("state", None)
+
+        if requested_state == "ABORTED":
+            if p.status[-1].state == State.ABORTED:
+                return p
+            if p.status[-1].state == State.ABORTING:
+                return p
+            # abortable states are {PENDING, RECEIVED, STARTED, REJECTED, RETRY, READY}
+            if p.status[-1].state.value not in UNREADY_STATES.union({"READY"}):
+                raise InvalidPipeline(
+                    f"Pipeline {id} is not currently running and cannot be aborted.")
+            if not p.status[-1].task_id:
+                raise InvalidPipeline(
+                    f"Pipeline {id} is running but has no task_id; abort is not possible.")
+            AbortableAsyncResult(
+                p.status[-1].task_id,
+                app=info.context["request"].app.celery_app
+            ).abort()
+            p.status[-1].state = State.ABORTING
+            p.status[-1].abort_requested_at = datetime.now()
+            # Run blocking database update in thread pool
+            p = await run_in_threadpool(info.context["request"].app.backend.update, p)
+            logger.info(
+                f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=abort_pipeline, id={p.id}, name={p.name}, task_id={p.status[-1].task_id}")
+            return p
 
         # Update pipeline with new pipeline input
         p.parameters = pipeline_input_dict.get("parameters")
@@ -576,7 +602,7 @@ class Mutation:
             "runner") or info.context["request"].app.config["KEDRO_GRAPHQL_RUNNER"]
 
         # If PipelineInput is READY and pipeline is not already running
-        if pipeline_input_dict.get("state", None) == "READY" and p.status[-1].state.value not in UNREADY_STATES.union(["READY"]):
+        if requested_state == "READY" and p.status[-1].state.value not in UNREADY_STATES.union(["READY"]):
 
             if (p.status[-1].state.value != "STAGED"):
                 # Add new status object to pipeline because this is another run attempt
@@ -620,7 +646,7 @@ class Mutation:
                 f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=run_pipeline, id={p.id}, name={p.name}, state=READY, task_id={result.task_id}")
 
         # If PipelineInput is STAGED and pipeline is not already running or staged
-        elif pipeline_input_dict.get("state", None) == "STAGED" and p.status[-1].state.value not in UNREADY_STATES.union(["READY"]) and p.status[-1].state.value != "STAGED":
+        elif requested_state == "STAGED" and p.status[-1].state.value not in UNREADY_STATES.union(["READY"]) and p.status[-1].state.value != "STAGED":
             p.status.append(PipelineStatus(state=State.STAGED,
                                            runner=runner,
                                            session=None,

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -1,13 +1,18 @@
-import asyncio
 import json
 import logging
+import billiard # celery's multiprocessing fork
 import os
+import queue
 import shutil
+import signal
+import time
+import traceback
 from datetime import date, datetime
 from pathlib import Path
 from typing import Dict, List
 
-from celery import Task, shared_task
+from celery import shared_task
+from celery.contrib.abortable import AbortableTask
 from kedro import __version__ as kedro_version
 from kedro.framework.project import pipelines
 from kedro.framework.session import KedroSession
@@ -17,21 +22,16 @@ from omegaconf import OmegaConf
 from kedro_graphql.logs.logger import KedroGraphQLLogHandler
 from kedro_graphql.utils import add_param_to_feed_dict
 from kedro_graphql.runners import init_runner
-from kedro_graphql.models import PipelineInput, ParameterInput, Pipeline
 
 # from .config import load_config
 from .models import DataSet, State
-from .client import PIPELINE_GQL
-
-from cloudevents.pydantic.v1 import CloudEvent
-from cloudevents.conversion import from_json, to_json
 
 logger = logging.getLogger(__name__)
 # CONFIG = load_config()
 # logger.debug("configuration loaded by {s}".format(s=__name__))
 
 
-class KedroGraphqlTask(Task):
+class KedroGraphqlTask(AbortableTask):
 
     _db = None
     _gql_config = None
@@ -61,9 +61,12 @@ class KedroGraphqlTask(Task):
         Returns:
             None: The return value of this handler is ignored.
         """
+        kedro_logger = logging.getLogger("kedro")
         handler = KedroGraphQLLogHandler(
             task_id, broker_url=self._app.conf["broker_url"])
-        logging.getLogger("kedro").addHandler(handler)
+        # Tag handlers so we can cleanly remove only this task's handlers later.
+        handler.kedro_graphql_task_id = task_id
+        kedro_logger.addHandler(handler)
         p = self.db.read(id=kwargs["id"])
         if p is None:
             logger.error(
@@ -96,8 +99,10 @@ class KedroGraphqlTask(Task):
 
             error_handler.setLevel(logging.ERROR)
             error_handler.setFormatter(formatter)
-            logging.getLogger("kedro").addHandler(info_handler)
-            logging.getLogger("kedro").addHandler(error_handler)
+            info_handler.kedro_graphql_task_id = task_id
+            error_handler.kedro_graphql_task_id = task_id
+            kedro_logger.addHandler(info_handler)
+            kedro_logger.addHandler(error_handler)
             # logger.info(
             # f"Storing tmp logs in {os.path.join(CONFIG['KEDRO_GRAPHQL_LOG_TMP_DIR'], task_id)}")
             logger.info(
@@ -155,9 +160,12 @@ class KedroGraphqlTask(Task):
         """
 
         p = self.db.read(id=kwargs["id"])
-        if p is not None:
-            p.status[-1].state = State.SUCCESS
-            self.db.update(p)
+        if p is None:
+            return
+        if p.status[-1].state in {State.ABORTING, State.ABORTED}:
+            return
+        p.status[-1].state = State.SUCCESS
+        self.db.update(p)
 
     def on_retry(self, exc, task_id, args, kwargs, einfo):
         """Retry handler.
@@ -200,6 +208,8 @@ class KedroGraphqlTask(Task):
 
         p = self.db.read(id=kwargs["id"])
         if p is not None:
+            if p.status[-1].state in {State.ABORTING, State.ABORTED}:
+                return
             p.status[-1].state = State.FAILURE
             p.status[-1].task_exception = str(exc)
             p.status[-1].task_einfo = str(einfo)
@@ -228,18 +238,26 @@ class KedroGraphqlTask(Task):
             p.status[-1].task_result = str(retval)
             self.db.update(p)
 
-        logger.info("Closing log stream")
-
-        # Clean up log handlers
-        for handler in logger.handlers:
-            if isinstance(handler, KedroGraphQLLogHandler) and handler.topic == task_id:
+        logger.info("Closing log stream for task_id=%s", task_id)
+        # Clean up only this task's handlers from the kedro logger.
+        kedro_logger = logging.getLogger("kedro")
+        handlers_to_remove = [
+            h for h in list(kedro_logger.handlers)
+            if getattr(h, "kedro_graphql_task_id", None) == task_id
+        ]
+        for handler in handlers_to_remove:
+            try:
                 handler.flush()
-                handler.close()
-                handler.broker.connection.delete(task_id)  # delete stream
-                handler.broker.connection.close()
-            if isinstance(handler, logging.FileHandler):
-                handler.close()
-        logger.handlers = []
+            except Exception:
+                pass
+            if isinstance(handler, KedroGraphQLLogHandler):
+                try:
+                    handler.broker.connection.delete(task_id)  # delete stream
+                    handler.broker.connection.close()
+                except Exception:
+                    pass
+            handler.close()
+            kedro_logger.removeHandler(handler)
 
         # Clear logs from temp_logs
         try:
@@ -252,6 +270,47 @@ class KedroGraphqlTask(Task):
             #    f"Failed to clear logs in {os.path.join(CONFIG['KEDRO_GRAPHQL_LOG_TMP_DIR'].name, task_id)}: {e}")
             logger.info(
                 f"Failed to clear logs in {os.path.join(self.gql_config['KEDRO_GRAPHQL_LOG_TMP_DIR'], task_id)}: {e}")
+
+
+def _run_pipeline_in_child_process(
+    runner_instance,
+    filtered_pipeline,
+    io,
+    hook_manager,
+    session_id: str,
+    record_data: dict,
+    pipeline_name: str,
+    result_queue,
+):
+    """Execute Kedro pipeline in a child process and report result via queue."""
+    try:
+        # Put child in its own process group so parent can signal descendants.
+        os.setsid()
+    except OSError:
+        pass
+
+    try:
+        run_result = runner_instance.run(
+            filtered_pipeline,
+            catalog=io,
+            hook_manager=hook_manager,
+            session_id=session_id,
+        )
+        hook_manager.hook.after_pipeline_run(
+            run_params=record_data,
+            run_result=run_result,
+            pipeline=pipelines.get(pipeline_name, None),
+            catalog=io,
+        )
+        result_queue.put({"status": "success"})
+    except BaseException as child_error:
+        result_queue.put(
+            {
+                "status": "error",
+                "error": str(child_error),
+                "traceback": traceback.format_exc(),
+            }
+        )
 
 
 @shared_task(bind=True, base=KedroGraphqlTask)
@@ -409,15 +468,116 @@ def run_pipeline(self,
             p.status[-1].filtered_nodes = [node.name for node in filtered_pipeline.nodes]
             self.db.update(p)
 
-            run_result = runner_instance.run(filtered_pipeline, catalog=io,
-                                      hook_manager=hook_manager, session_id=session.session_id)
+            # Use Celery's multiprocessing library (billiard) instead of multiprocessing
+            # to avoid AssertionError: daemonic processes are not allowed to have children
+            ctx = billiard.get_context("fork")
 
-            hook_manager.hook.after_pipeline_run(
-                run_params=record_data,
-                run_result=run_result,
-                pipeline=pipelines.get(name, None),
-                catalog=io
+            # queue to communicate with the child process
+            result_queue = ctx.Queue(maxsize=1)
+            child = ctx.Process(
+                target=_run_pipeline_in_child_process,
+                args=(
+                    runner_instance,
+                    filtered_pipeline,
+                    io,
+                    hook_manager,
+                    session.session_id,
+                    record_data,
+                    name,
+                    result_queue,
+                ),
             )
+            child.start()
+
+            polling_interval = self.gql_config.get(
+                "KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL", 5
+            )
+            try:
+                polling_interval = float(polling_interval)
+                if polling_interval < 1:
+                    logger.warning(
+                        "KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL=%s is below minimum 1s; clamping to 1s",
+                        polling_interval,
+                    )
+                    polling_interval = 1.0
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL=%s, falling back to 5s",
+                    polling_interval,
+                )
+                polling_interval = 5.0
+            grace_period = self.gql_config.get(
+                "KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD", 60
+            )
+            try:
+                grace_period = float(grace_period)
+                if grace_period < 5:
+                    logger.warning(
+                        "KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD=%s is below minimum 5s; clamping to 5s",
+                        grace_period,
+                    )
+                    grace_period = 5.0
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD=%s, falling back to 60s",
+                    grace_period,
+                )
+                grace_period = 60.0
+            
+            sigint_sent_at = None
+            sigterm_sent_at = None
+
+            while child.is_alive():
+                if self.is_aborted():
+                    now = time.monotonic()
+                    if sigint_sent_at is None:
+                        logger.info("Abort requested for task=%s; sending SIGINT to child pid=%s", self.request.id, child.pid)
+                        try:
+                            os.killpg(os.getpgid(child.pid), signal.SIGINT)
+                        except ProcessLookupError:
+                            pass
+                        sigint_sent_at = now
+                    elif now - sigint_sent_at >= grace_period and sigterm_sent_at is None:
+                        logger.warning("Child pid=%s did not exit after SIGINT; escalating to SIGTERM", child.pid)
+                        try:
+                            os.killpg(os.getpgid(child.pid), signal.SIGTERM)
+                        except ProcessLookupError:
+                            pass
+                        sigterm_sent_at = now
+                    elif sigterm_sent_at is not None and now - sigterm_sent_at >= grace_period:
+                        logger.error("Child pid=%s did not exit after SIGTERM; escalating to SIGKILL", child.pid)
+                        try:
+                            os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+                    # Quick checks to see if the child process has exited
+                    child.join(timeout=1)
+                else:
+                    # Interval to check if child process should be aborted
+                    child.join(timeout=polling_interval)
+
+            child.join()
+
+            child_result = {
+                "status": "error",
+                "error": "Child process exited without returning a result",
+            }
+            try:
+                child_result = result_queue.get_nowait()
+            except queue.Empty:
+                logger.warning("Child process pid=%s finished without posting a result", child.pid)
+
+            if self.is_aborted():
+                p = self.db.read(id=id)
+                if p is not None:
+                    p.status[-1].state = State.ABORTED
+                    p.status[-1].abort_completed_at = datetime.now()
+                    self.db.update(p)
+                return "aborted"
+
+            if child_result.get("status") != "success":
+                error_message = child_result.get("error", "Unknown child process error")
+                raise RuntimeError(error_message)
 
             return "success"
         except Exception as e:

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -22,9 +22,14 @@ from omegaconf import OmegaConf
 from kedro_graphql.logs.logger import KedroGraphQLLogHandler
 from kedro_graphql.utils import add_param_to_feed_dict
 from kedro_graphql.runners import init_runner
+from kedro_graphql.models import PipelineInput, ParameterInput, Pipeline
 
 # from .config import load_config
 from .models import DataSet, State
+from .client import PIPELINE_GQL
+
+from cloudevents.pydantic.v1 import CloudEvent
+from cloudevents.conversion import from_json, to_json
 
 logger = logging.getLogger(__name__)
 # CONFIG = load_config()

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -243,7 +243,6 @@ class KedroGraphqlTask(AbortableTask):
             p.status[-1].task_result = str(retval)
             self.db.update(p)
 
-        logger.info("Closing log stream for task_id=%s", task_id)
         # Clean up only this task's handlers from the kedro logger.
         kedro_logger = logging.getLogger("kedro")
         handlers_to_remove = [
@@ -317,7 +316,6 @@ def _run_pipeline_in_child_process(
             }
         )
 
-
 @shared_task(bind=True, base=KedroGraphqlTask)
 def run_pipeline(self,
                  id: str = None,
@@ -338,6 +336,13 @@ def run_pipeline(self,
         hook_manager = session._hook_manager
 
         p = self.db.read(id=id)
+        if p is None:
+            logger.warning(
+                "Pipeline id=%s not found in backend during run_pipeline; task_id=%s",
+                id,
+                self.request.id,
+            )
+            return
         p.status[-1].session = session.session_id
         self.db.update(p)
 
@@ -538,21 +543,37 @@ def run_pipeline(self,
                     if sigint_sent_at is None:
                         logger.info("Abort requested for task=%s; sending SIGINT to child pid=%s", self.request.id, child.pid)
                         try:
-                            os.killpg(os.getpgid(child.pid), signal.SIGINT)
+                            child_pgid = os.getpgid(child.pid)
+                            # there could be a small window where the child process doesn't yet have its own process group
+                            # so we ensure we don't signal the parent process group
+                            if child_pgid == os.getpgrp():
+                                # send SIGINT to the child process directly
+                                os.kill(child.pid, signal.SIGINT)
+                            else:
+                                # send SIGINT to the child process's process group
+                                os.killpg(child_pgid, signal.SIGINT)
                         except ProcessLookupError:
                             pass
                         sigint_sent_at = now
                     elif now - sigint_sent_at >= grace_period and sigterm_sent_at is None:
                         logger.warning("Child pid=%s did not exit after SIGINT; escalating to SIGTERM", child.pid)
                         try:
-                            os.killpg(os.getpgid(child.pid), signal.SIGTERM)
+                            child_pgid = os.getpgid(child.pid)
+                            if child_pgid == os.getpgrp():
+                                os.kill(child.pid, signal.SIGTERM)
+                            else:
+                                os.killpg(child_pgid, signal.SIGTERM)
                         except ProcessLookupError:
                             pass
                         sigterm_sent_at = now
                     elif sigterm_sent_at is not None and now - sigterm_sent_at >= grace_period:
                         logger.error("Child pid=%s did not exit after SIGTERM; escalating to SIGKILL", child.pid)
                         try:
-                            os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+                            child_pgid = os.getpgid(child.pid)
+                            if child_pgid == os.getpgrp():
+                                os.kill(child.pid, signal.SIGKILL)
+                            else:
+                                os.killpg(child_pgid, signal.SIGKILL)
                         except ProcessLookupError:
                             pass
                     # Quick checks to see if the child process has exited

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -144,7 +144,7 @@ def celery_config():
     return {
         'broker_url': 'redis://',
         'result_backend': 'redis://',
-        'result_extened': True,
+        'result_extended': True,
         'worker_send_task_events': True,
         'task_send_sent_event': True,
         'task_store_eager_result': True,

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -133,6 +133,8 @@ def mock_app(kedro_session):
             app = KedroGraphQL(kedro_session=kedro_session, config=config)
             app.config["KEDRO_GRAPHQL_LOG_PATH_PREFIX"] = tmp
             app.config["KEDRO_GRAPHQL_LOG_TMP_DIR"] = tmp2
+            app.config["KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL"] = 1
+            app.config["KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD"] = 5
 
             yield app
 

--- a/src/tests/test_schema_mutation.py
+++ b/src/tests/test_schema_mutation.py
@@ -370,6 +370,7 @@ class TestSchemaMutations:
     @pytest.mark.asyncio
     async def test_update_pipeline_abort_non_running_fails(self,
                                                            mock_app,
+                                                           mock_info_context,
                                                            mock_pipeline_staged):
         resp = await mock_app.schema.execute(
             self.update_pipeline_mutation,
@@ -385,6 +386,9 @@ class TestSchemaMutations:
     @pytest.mark.asyncio
     async def test_update_pipeline_abort(self,
                                          mock_app,
+                                         mock_celery_session_app,
+                                         celery_session_worker,
+                                         mock_info_context,
                                          mock_text_in,
                                          mock_text_out):
         create_resp = await mock_app.schema.execute(

--- a/src/tests/test_schema_mutation.py
+++ b/src/tests/test_schema_mutation.py
@@ -1,7 +1,10 @@
 import json
 import time
+import asyncio
+from unittest.mock import patch
 
 import pytest
+from kedro_graphql.models import State
 
 IN_DEV = True
 
@@ -363,6 +366,98 @@ class TestSchemaMutations:
             "key": "author", "value": "opensean"}
         assert update_pipeline_resp.data["updatePipeline"]["tags"][1] == {
             "key": "package", "value": "kedro-graphql"}
+
+    @pytest.mark.asyncio
+    async def test_update_pipeline_abort_non_running_fails(self,
+                                                           mock_app,
+                                                           mock_pipeline_staged):
+        resp = await mock_app.schema.execute(
+            self.update_pipeline_mutation,
+            variable_values={
+                "id": str(mock_pipeline_staged.id),
+                "pipeline": {"name": mock_pipeline_staged.name, "state": "ABORTED"},
+                "uniquePaths": None,
+            },
+        )
+        assert resp.errors is not None
+        assert "cannot be aborted" in str(resp.errors[0]).lower()
+
+    @pytest.mark.asyncio
+    async def test_update_pipeline_abort(self,
+                                         mock_app,
+                                         mock_text_in,
+                                         mock_text_out):
+        create_resp = await mock_app.schema.execute(
+            self.create_pipeline_mutation,
+            variable_values={"pipeline": {
+                "name": "example00",
+                "dataCatalog": [{"name": "text_in", "config": json.dumps({"type": "text.TextDataset", "filepath": str(mock_text_in)})},
+                                {"name": "text_out", "config": json.dumps(
+                                    {"type": "text.TextDataset", "filepath": str(mock_text_out)})}
+                                ],
+                "parameters": [{"name": "example", "value": "hello"},
+                               {"name": "duration", "value": "8", "type": "FLOAT"}],
+                "tags": [{"key": "author", "value": "opensean"}, {"key": "package", "value": "kedro-graphql"}],
+                "state": "READY",
+            }, "uniquePaths": None})
+        assert create_resp.errors is None
+        pipeline_id = create_resp.data["createPipeline"]["id"]
+
+        # wait for task id before requesting abort
+        TASK_ID_ASSIGNMENT_TIMEOUT_SEC = 10.0
+        ABORT_SUBSCRIPTION_TIMEOUT_SEC = 20.0
+        deadline = time.monotonic() + TASK_ID_ASSIGNMENT_TIMEOUT_SEC
+        p = None
+        while time.monotonic() < deadline:
+            p = mock_app.backend.read(id=pipeline_id)
+            if p and p.status[-1].task_id:
+                break
+            await asyncio.sleep(0.1)
+        assert p is not None and p.status[-1].task_id is not None
+
+        abort_resp = await mock_app.schema.execute(
+            self.update_pipeline_mutation,
+            variable_values={
+                "id": pipeline_id,
+                "pipeline": {"name": p.name, "state": "ABORTED"},
+                "uniquePaths": None,
+            },
+        )
+        assert abort_resp.errors is None
+        assert abort_resp.data["updatePipeline"]["status"][-1]["state"] == "ABORTING"
+
+        query = """
+          subscription {
+            pipeline(id:""" + '"' + str(pipeline_id) + '"' + """) {
+              traceback
+              timestamp
+              taskId
+              status
+              result
+              id
+            }
+          }
+        """
+        sub = await mock_app.schema.subscribe(query)
+
+        events = []
+        deadline = time.monotonic() + ABORT_SUBSCRIPTION_TIMEOUT_SEC
+        async for result in sub:
+            assert not result.errors
+            event = result.data["pipeline"]
+            events.append(event)
+            if event["status"] == "SUCCESS":
+                break
+            if time.monotonic() > deadline:
+                raise AssertionError("Timed out waiting for SUCCESS event after abort request")
+
+        assert len(events) > 0
+        assert events[-1]["status"] == "SUCCESS"
+        assert str(events[-1]["result"]).lower() == "aborted"
+
+        updated = mock_app.backend.read(id=pipeline_id)
+        assert updated is not None
+        assert updated.status[-1].state == State.ABORTED
 
     @pytest.mark.asyncio
     async def test_delete_pipeline(self,

--- a/src/tests/test_schema_mutation.py
+++ b/src/tests/test_schema_mutation.py
@@ -2,6 +2,7 @@ import json
 import time
 import asyncio
 from unittest.mock import patch
+from celery.states import UNREADY_STATES
 
 import pytest
 from kedro_graphql.models import State
@@ -376,8 +377,7 @@ class TestSchemaMutations:
             self.update_pipeline_mutation,
             variable_values={
                 "id": str(mock_pipeline_staged.id),
-                "pipeline": {"name": mock_pipeline_staged.name, "state": "ABORTED"},
-                "uniquePaths": None,
+                "pipeline": {"name": mock_pipeline_staged.name, "state": "ABORTED"}
             },
         )
         assert resp.errors is not None
@@ -400,62 +400,79 @@ class TestSchemaMutations:
                                     {"type": "text.TextDataset", "filepath": str(mock_text_out)})}
                                 ],
                 "parameters": [{"name": "example", "value": "hello"},
-                               {"name": "duration", "value": "8", "type": "FLOAT"}],
-                "tags": [{"key": "author", "value": "opensean"}, {"key": "package", "value": "kedro-graphql"}],
+                               {"name": "duration", "value": "60", "type": "FLOAT"}],
+                "tags": [{"key": "author", "value": "harinlee83"}, {"key": "package", "value": "kedro-graphql"}],
                 "state": "READY",
-            }, "uniquePaths": None})
+            }})
         assert create_resp.errors is None
         pipeline_id = create_resp.data["createPipeline"]["id"]
 
-        # wait for task id before requesting abort
-        TASK_ID_ASSIGNMENT_TIMEOUT_SEC = 10.0
-        ABORT_SUBSCRIPTION_TIMEOUT_SEC = 20.0
-        deadline = time.monotonic() + TASK_ID_ASSIGNMENT_TIMEOUT_SEC
-        p = None
-        while time.monotonic() < deadline:
-            p = mock_app.backend.read(id=pipeline_id)
-            if p and p.status[-1].task_id:
-                break
-            await asyncio.sleep(0.1)
-        assert p is not None and p.status[-1].task_id is not None
-
-        abort_resp = await mock_app.schema.execute(
-            self.update_pipeline_mutation,
-            variable_values={
-                "id": pipeline_id,
-                "pipeline": {"name": p.name, "state": "ABORTED"},
-                "uniquePaths": None,
-            },
-        )
-        assert abort_resp.errors is None
-        assert abort_resp.data["updatePipeline"]["status"][-1]["state"] == "ABORTING"
-
+        # Confirm the pipeline is running before sending an abort request.
         query = """
-          subscription {
+          subscription MySubscription {
             pipeline(id:""" + '"' + str(pipeline_id) + '"' + """) {
-              traceback
-              timestamp
-              taskId
               status
-              result
+              taskId
               id
             }
           }
         """
         sub = await mock_app.schema.subscribe(query)
 
-        events = []
-        deadline = time.monotonic() + ABORT_SUBSCRIPTION_TIMEOUT_SEC
-        async for result in sub:
-            assert not result.errors
-            event = result.data["pipeline"]
-            events.append(event)
-            if event["status"] == "SUCCESS":
-                break
-            if time.monotonic() > deadline:
-                raise AssertionError("Timed out waiting for SUCCESS event after abort request")
+        async def wait_for_started_event():
+            async for result in sub:
+                assert not result.errors
+                event = result.data["pipeline"]
+                if event["status"] == "PENDING" and event["taskId"] is not None:
+                    return event
+
+        started_event = await asyncio.wait_for(wait_for_started_event(), timeout=30.0)
+        assert started_event["id"] == pipeline_id
+        assert started_event["status"] in UNREADY_STATES
+        assert started_event["taskId"] is not None
+        p = mock_app.backend.read(id=pipeline_id)
+        assert p is not None
+
+        # Send an abort request
+        abort_resp = await mock_app.schema.execute(
+            self.update_pipeline_mutation,
+            variable_values={
+                "id": pipeline_id,
+                "pipeline": {"name": p.name, "state": "ABORTED"},
+            }
+        )
+        assert abort_resp.errors is None
+        assert abort_resp.data["updatePipeline"]["status"][-1]["state"] == "ABORTING"
+
+        # Subscribe to confirm pipeline aborts successfully.
+        query = """
+          subscription MySubscription {
+            pipeline(id:""" + '"' + str(pipeline_id) + '"' + """) {
+              status
+              taskId
+              result
+              id
+              timestamp
+              traceback
+            }
+          }
+        """
+        sub = await mock_app.schema.subscribe(query)
+
+        async def wait_for_aborted_event():
+            events = []
+            async for result in sub:
+                assert not result.errors
+                event = result.data["pipeline"]
+                events.append(event)
+                if event["status"] == "SUCCESS":
+                    return events
+            return events
+
+        events = await asyncio.wait_for(wait_for_aborted_event(), timeout=90.0)
 
         assert len(events) > 0
+        assert events[-1]["id"] == pipeline_id
         assert events[-1]["status"] == "SUCCESS"
         assert str(events[-1]["result"]).lower() == "aborted"
 


### PR DESCRIPTION
## Timing Diagram

```mermaid
sequenceDiagram
    autonumber
    participant Client
    participant API as GraphQL (updatePipeline)
    participant Redis as Redis (abort flag)
    participant Worker as Celery worker (run_pipeline parent)
    participant Child as Child process (Kedro run)

    Client->>API: updatePipeline(state: ABORTED)
    API->>Redis: AbortableAsyncResult.abort() sets abort flag
    API->>API: DB: ABORTING, abort_requested_at
    API-->>Client: 200 ABORTING

    Note over Worker,Child: Parent loop: each tick waits up to polling_interval (non-abort) or ~1s (abort path)

    loop Until child exits or abort handled
        Worker->>Redis: is_aborted() (implicit via AbortableTask)
        alt Not aborted yet
            Worker->>Worker: join(child, timeout = polling_interval)
        else Aborted
            Worker->>Child: SIGINT (process group)
            Note over Worker,Child: Wait up to grace_period (checked on ~1s ticks)
            opt Still running after grace_period
                Worker->>Child: SIGTERM
                Note over Worker,Child: Wait up to grace_period again
            end
            opt Still running after second grace
                Worker->>Child: SIGKILL
            end
            Worker->>Worker: join(child, short timeout)
        end
    end

    Worker->>Worker: DB: ABORTED, abort_completed_at (if abort path)
    Worker-->>Worker: after_return, SUCCESS (Celery) + task_result "aborted"

```
Added:

- `ABORTED` to both `PipelineInputStatus` and pipeline `State` enums so clients can request and observe pipeline aborts through GraphQL
- `ABORTING` pipeline state and `abort_requested_at` / `abort_completed_at` timestamps on `PipelineStatus` for explicit abort lifecycle tracking
- `KEDRO_GRAPHQL_CELERY_ABORT_POLLING_INTERVAL` (default `5`) for controlling abort check frequency in Celery task execution (values below `1` second are clamped at runtime)
- `KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD` (default `60`) for controlling how long the worker waits before escalating abort signals (values below `5` seconds are clamped at runtime)
- CLI flags `--celery-abort-polling-interval` and `--celery-abort-grace-period` on `kedro gql` to override the above settings
- Schema mutation tests for aborting a running pipeline and rejecting abort requests for non-running pipelines

Changed:

- `KedroGraphqlTask` now inherits from Celery `AbortableTask`
- `run_pipeline` now executes the Kedro runner in a child subprocess while the parent task monitors abort status and sends OS signals (`SIGINT` first, then escalation)
- `updatePipeline` now handles `state: ABORTED` by calling `AbortableAsyncResult.abort()` and persisting `ABORTING` in the document backend until worker-side abort completion; repeated abort requests while already `ABORTING` or `ABORTED` return without error
- Task `on_success` and `on_failure` handlers now preserve abort states and avoid overwriting `ABORTING`/`ABORTED` with `SUCCESS` or `FAILURE`

Fixed:

- Kedro log handlers added during pipeline runs are now removed from the `kedro` logger (not the task module logger), tagged per Celery task id, reducing duplicate log output and teardown noise
- Pipeline `State` enum typo corrected from `RECIEVED` to `RECEIVED`