### PR TITLE
Fix/abort status and logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Fixed:
 - `PipelineLogStream` now always closes async Redis connections with `aclose()` via `finally`, including subscription cancellation/disconnect paths
 - `PipelineLogStream` terminal state detection now includes explicit `ABORTED` status
 - Plugin registration logs now use correct labels for mutation and subscription plugin types
+- `MongoBackend` now detects fork boundaries and recreates `MongoClient` per process to eliminate fork-safety warnings
+- Celery config now sets `broker_connection_retry_on_startup=True` to suppress deprecation warning for future Celery 6.0 compatibility
 
 ## [1.5.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Added:
 - `KEDRO_GRAPHQL_CELERY_ABORT_GRACE_PERIOD` (default `60`) for controlling how long the worker waits before escalating abort signals (values below `5` seconds are clamped at runtime)
 - CLI flags `--celery-abort-polling-interval` and `--celery-abort-grace-period` on `kedro gql` to override the above settings
 - Schema mutation tests for aborting a running pipeline and rejecting abort requests for non-running pipelines
+- Documentation updates for log subscriptions, including custom log capture guidance and refreshed `pipelineLogs` examples
 
 Changed:
 
@@ -23,6 +24,9 @@ Changed:
 - `run_pipeline` now executes the Kedro runner in a child subprocess while the parent task monitors abort status and sends OS signals (`SIGINT` first, then escalation)
 - `updatePipeline` now handles `state: ABORTED` by calling `AbortableAsyncResult.abort()` and persisting `ABORTING` in the document backend until worker-side abort completion; repeated abort requests while already `ABORTING` or `ABORTED` return without error
 - Task `on_success` and `on_failure` handlers now preserve abort states and avoid overwriting `ABORTING`/`ABORTED` with `SUCCESS` or `FAILURE`
+- Pipeline subscription events now map Celery `SUCCESS` with result `aborted` to `ABORTED` so streamed status aligns with pipeline abort semantics
+- Task-scoped log stream handlers are now attached to the root logger so propagated logs from Kedro and custom modules are captured consistently
+- Task subprocess logging reinitializes stream handlers in the child process to keep Redis stream publishing process-local after fork
 
 Fixed:
 
@@ -32,6 +36,9 @@ Fixed:
 - `after_return` temp log cleanup logging bug (`.name` used on string path)
 - Kedro log handlers added during pipeline runs are now removed from the `kedro` logger (not the task module logger), tagged per Celery task id, reducing duplicate log output and teardown noise
 - Pipeline `State` enum typo corrected from `RECIEVED` to `RECEIVED`
+- `PipelineLogStream` now always closes async Redis connections with `aclose()` via `finally`, including subscription cancellation/disconnect paths
+- `PipelineLogStream` terminal state detection now includes explicit `ABORTED` status
+- Plugin registration logs now use correct labels for mutation and subscription plugin types
 
 ## [1.5.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Fixed:
 - Plugin registration logs now use correct labels for mutation and subscription plugin types
 - `MongoBackend` now detects fork boundaries and recreates `MongoClient` per process to eliminate fork-safety warnings
 - Celery config now sets `broker_connection_retry_on_startup=True` to suppress deprecation warning for future Celery 6.0 compatibility
+- Child pipeline process now handles `SIGINT`/`SIGTERM` gracefully during abort so logs flush and hook-based log persistence still run before exit
 
 ## [1.5.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Fixed:
 - `MongoBackend` now detects fork boundaries and recreates `MongoClient` per process to eliminate fork-safety warnings
 - Celery config now sets `broker_connection_retry_on_startup=True` to suppress deprecation warning for future Celery 6.0 compatibility
 - Child pipeline process now handles `SIGINT`/`SIGTERM` gracefully during abort so logs flush and hook-based log persistence still run before exit
+- Tests now use an isolated Redis DB and flush it before/after the session to clean up Celery result keys and stream artifacts
 
 ## [1.5.1] - 2026-03-31
 

--- a/docs/extend_graphql.md
+++ b/docs/extend_graphql.md
@@ -40,8 +40,52 @@ When starting the api server specify the import path using the
 kedro gql --imports "kedro_graphql.plugins.plugins"
 ```
 
-Multiple import paths can be specified using comma seperated values.
+Multiple import paths can be specified using comma separated values.
 
 ```bash
 kedro gql --imports "kedro_graphql.plugins.plugins,example_pkg.example.my_types"
 ```
+
+## Capture custom logs in `pipelineLogs`
+
+`pipelineLogs` streams logs from the active pipeline task using a task-scoped Redis stream.
+To ensure your custom logs are included consistently:
+
+1. Use Python logging (avoid `print()` for pipeline runtime messages).
+2. Log from any module logger (for example `logging.getLogger(__name__)`).
+3. Keep logger propagation enabled (default behavior) so records reach the root logger.
+
+### Example: custom node logs
+
+```python
+import logging
+
+node_logger = logging.getLogger(__name__)
+
+
+def enrich_features(df):
+    node_logger.info("starting feature enrichment")
+    # ... node logic ...
+    node_logger.info("feature enrichment completed")
+    return df
+```
+
+### Example: subscribe to pipeline logs
+
+```graphql
+subscription MyPipelineLogs {
+    pipelineLogs(id: "67b795d44f0f5729b9b5730e") {
+        id
+        taskId
+        messageId
+        time
+        message
+    }
+}
+```
+
+### Notes
+
+- `pipelineLogs` is per task run; it starts streaming once a `taskId` exists.
+- The subscription requires the `subscribe_to_logs` permission action.
+- For consistent output, prefer a single logging style (`logger.info`, `logger.warning`, `logger.error`) across custom code.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -161,9 +161,9 @@ subscription MySubscription {
 
 ![subscription](https://raw.githubusercontent.com/cellsignal/kedro-graphql/refs/heads/main/docs/subscription.gif)
 
-### Susbscribe to pipeline logs
+### Subscribe to pipeline logs
 
-Execute the following subscription to recieve log messages:
+Execute the following subscription to receive log messages:
 
 ```graphql
 subscription MySubscriptionLogs {

--- a/src/kedro_graphql/backends/mongodb.py
+++ b/src/kedro_graphql/backends/mongodb.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import os
 import uuid
 
 from bson.objectid import ObjectId
@@ -13,12 +14,22 @@ from .base import BaseBackend
 class MongoBackend(BaseBackend):
 
     def __init__(self, uri=None, db=None, collection="pipelines"):
-        self.client = MongoClient(uri)
-        self.db = self.client[db]
+        self.uri = uri
+        self.db_name = db
+        self.client = MongoClient(self.uri)
+        self.db = self.client[self.db_name]
+        # Track process id to detect fork boundaries.
+        self.client_pid = os.getpid()
         self.collection = collection
 
     def startup(self, **kwargs):
         """Startup hook."""
+        # Recreate client if this process was forked after backend initialization.
+        if self.client_pid != os.getpid():
+            self.client.close()
+            self.client = MongoClient(self.uri)
+            self.db = self.client[self.db_name]
+            self.client_pid = os.getpid()
         print("Connected to the MongoDB database!")
 
     def shutdown(self, **kwargs):
@@ -26,6 +37,13 @@ class MongoBackend(BaseBackend):
         self.client.close()
 
     def list(self, cursor: uuid.UUID = None, limit=10, filter="", sort=""):
+        # Recreate client if this method is running in a different process.
+        if self.client_pid != os.getpid():
+            self.client.close()
+            self.client = MongoClient(self.uri)
+            self.db = self.client[self.db_name]
+            self.client_pid = os.getpid()
+
         query = {}
         if len(filter) > 0:
             filter = json.loads(filter)
@@ -56,6 +74,13 @@ class MongoBackend(BaseBackend):
 
     def read(self, id: uuid.UUID = None, task_id: str = None):
         """Load a pipeline by id or task_id"""
+        # Recreate client if this method is running in a different process.
+        if self.client_pid != os.getpid():
+            self.client.close()
+            self.client = MongoClient(self.uri)
+            self.db = self.client[self.db_name]
+            self.client_pid = os.getpid()
+
         if task_id:
             r = self.db[self.collection].find_one(
                 {"status": {"$elemMatch": {"task_id": task_id}}})
@@ -71,6 +96,13 @@ class MongoBackend(BaseBackend):
 
     def create(self, pipeline: Pipeline):
         """Save a pipeline"""
+        # Recreate client if this method is running in a different process.
+        if self.client_pid != os.getpid():
+            self.client.close()
+            self.client = MongoClient(self.uri)
+            self.db = self.client[self.db_name]
+            self.client_pid = os.getpid()
+
         values = pipeline.encode()
         values.pop("id")  # we dont have an id yet, we will get it after insert
         created = self.db[self.collection].insert_one(values)
@@ -81,6 +113,13 @@ class MongoBackend(BaseBackend):
 
     def update(self, pipeline: Pipeline = None):
         """Update a pipeline"""
+        # Recreate client if this method is running in a different process.
+        if self.client_pid != os.getpid():
+            self.client.close()
+            self.client = MongoClient(self.uri)
+            self.db = self.client[self.db_name]
+            self.client_pid = os.getpid()
+
         id = ObjectId(pipeline.id)
         filter = {'_id': id}
         values = pipeline.encode()
@@ -94,5 +133,12 @@ class MongoBackend(BaseBackend):
 
     def delete(self, id: uuid.UUID = None):
         """Delete a pipeline using id"""
+        # Recreate client if this method is running in a different process.
+        if self.client_pid != os.getpid():
+            self.client.close()
+            self.client = MongoClient(self.uri)
+            self.db = self.client[self.db_name]
+            self.client_pid = os.getpid()
+
         self.db[self.collection].delete_one({"_id": ObjectId(id)})
         return id

--- a/src/kedro_graphql/celeryapp.py
+++ b/src/kedro_graphql/celeryapp.py
@@ -17,6 +17,7 @@ def celery_app(config, backend, schema):
         task_send_sent_event = True
         imports = "kedro_graphql.tasks"
         worker_soft_shutdown_timeout = 10
+        broker_connection_retry_on_startup = True
 
     app.config_from_object(Config)
     app.kedro_graphql_backend = backend

--- a/src/kedro_graphql/decorators.py
+++ b/src/kedro_graphql/decorators.py
@@ -50,7 +50,7 @@ def gql_mutation():
 
     def register_plugin(plugin_class):
         TYPE_PLUGINS["mutation"].append(plugin_class)
-        logger.info("registered type plugin 'query': " + str(plugin_class))
+        logger.info("registered type plugin 'mutation': " + str(plugin_class))
         return plugin_class
 
     return register_plugin
@@ -60,7 +60,7 @@ def gql_subscription():
 
     def register_plugin(plugin_class):
         TYPE_PLUGINS["subscription"].append(plugin_class)
-        logger.info("registered type plugin 'query': " + str(plugin_class))
+        logger.info("registered type plugin 'subscription': " + str(plugin_class))
         return plugin_class
 
     return register_plugin

--- a/src/kedro_graphql/logs/logger.py
+++ b/src/kedro_graphql/logs/logger.py
@@ -13,7 +13,7 @@ from starlette.concurrency import run_in_threadpool
 
 from .json_log_formatter import JSONFormatter  # VerboseJSONFormatter also available
 
-logger = logging.getLogger("kedro-graphql")
+logger = logging.getLogger("kedro_graphql")
 logger.setLevel(logging.INFO)
 
 
@@ -22,12 +22,25 @@ class RedisLogStreamPublisher(object):
         self.connection = redis.Redis.from_url(broker_url)
         self.topic = topic
         if not self.connection.exists(self.topic):
+            bootstrap_payload = json.loads(
+                JSONFormatter().format(
+                    LogRecord(
+                        "kedro_graphql",
+                        20,
+                        os.path.abspath(__file__),
+                        getframeinfo(currentframe()).lineno,
+                        "Starting log stream",
+                        None,
+                        None,
+                    )
+                )
+            )
+            bootstrap_payload.setdefault("level", "INFO")
+            bootstrap_payload.setdefault("logger", "kedro_graphql")
             self.connection.xadd(
-                self.topic, json.loads(
-                    JSONFormatter().format(
-                        LogRecord(
-                            "kedro-graphql", 20, os.path.abspath(__file__),
-                            getframeinfo(currentframe()).lineno, "Starting log stream", None, None))))
+                self.topic,
+                bootstrap_payload,
+            )
             # stream will expire in 24 hours (safety mechanism in case task_postrun fails to delete)
             self.connection.expire(self.topic, 86400)
 
@@ -63,7 +76,10 @@ class KedroGraphQLLogHandler(logging.StreamHandler):
 
     def emit(self, record):
         msg = self.format(record)
-        self.broker.publish(json.loads(msg))
+        payload = json.loads(msg)
+        payload["level"] = record.levelname
+        payload["logger"] = record.name
+        self.broker.publish(payload)
 
 
 class PipelineLogStream():
@@ -80,31 +96,43 @@ class PipelineLogStream():
 
     async def consume(self) -> AsyncGenerator[dict, None]:
         start_id = 0
-        while True:
-            stream_data = await self.broker.consume(count=1, start_id=start_id)
-            if len(stream_data) > 0:
-                for id, value in stream_data[0][1]:
-                    yield {"task_id": self.task_id, "message_id": id.decode(), "message": value[b"message"].decode(), "time": value[b"time"].decode()}
-                # https://redis-py.readthedocs.io/en/stable/examples/redis-stream-example.html#read-more-data-from-the-stream
-                start_id = stream_data[0][1][-1][0]
-            else:
-                # check task status - wrap blocking Celery operation in thread pool
-                def check_task_status(task_id):
-                    try:
-                        r = AsyncResult(task_id)
-                        # Check if backend is disabled/not available
-                        if not hasattr(r.backend, '_get_task_meta_for'):
-                            # No result backend configured, can't check status
-                            # Return None to indicate we should keep streaming
+        try:
+            while True:
+                stream_data = await self.broker.consume(count=1, start_id=start_id)
+                if len(stream_data) > 0:
+                    for id, value in stream_data[0][1]:
+                        message = value.get(b"message", b"").decode()
+                        timestamp = value.get(b"time", b"").decode()
+                        yield {
+                            "task_id": self.task_id,
+                            "message_id": id.decode(),
+                            "message": message,
+                            "time": timestamp,
+                        }
+                    # https://redis-py.readthedocs.io/en/stable/examples/redis-stream-example.html#read-more-data-from-the-stream
+                    start_id = stream_data[0][1][-1][0]
+                else:
+                    # check task status - wrap blocking Celery operation in thread pool
+                    def check_task_status(task_id):
+                        try:
+                            r = AsyncResult(task_id)
+                            # Check if backend is disabled/not available
+                            if not hasattr(r.backend, '_get_task_meta_for'):
+                                # No result backend configured, can't check status
+                                # Return None to indicate we should keep streaming
+                                return None
+                            return r.status
+                        except (AttributeError, NotImplementedError):
+                            # Backend doesn't support status checking
                             return None
-                        return r.status
-                    except (AttributeError, NotImplementedError):
-                        # Backend doesn't support status checking
-                        return None
-                
-                status = await run_in_threadpool(check_task_status, self.task_id)
-                # Only break if we got a valid status and it's in READY_STATES
-                # If status is None (no backend), continue streaming
-                if status is not None and status in READY_STATES:
-                    await self.broker.connection.aclose()
-                    break
+
+                    status = await run_in_threadpool(check_task_status, self.task_id)
+                    # End streaming on normal terminal states and explicit ABORTED
+                    # (used by abortable tasks in some backends).
+                    terminal_statuses = set(READY_STATES).union({"ABORTED"})
+                    # If status is None (no backend), continue streaming.
+                    if status is not None and status in terminal_statuses:
+                        break
+        finally:
+            # Always close async Redis connection, including cancellation/disconnect.
+            await self.broker.connection.aclose()

--- a/src/kedro_graphql/pipeline_event_monitor.py
+++ b/src/kedro_graphql/pipeline_event_monitor.py
@@ -120,6 +120,7 @@ class PipelineEventMonitor:
             """Helper to get task state in thread pool - Celery AsyncResult properties are blocking."""
             try:
                 task = app.AsyncResult(task_id)
+
                 # Check if backend is disabled/not available
                 if not hasattr(task.backend, '_get_task_meta_for'):
                     # No result backend configured, return pending status
@@ -127,6 +128,16 @@ class PipelineEventMonitor:
                         "task_id": task_id,
                         "status": "PENDING",
                         "result": "No result backend configured",
+                        "timestamp": time.time(),
+                        "traceback": None
+                    }
+                # if task result is None and status is "ABORTED", change status to "ABORTING" to indicate that the task is in the process of being aborted
+                # celery doesn't have "ABORTING" status
+                if task.status == "ABORTED" and task.result is None:
+                    return {
+                        "task_id": task_id,
+                        "status": "ABORTING",
+                        "result": None,
                         "timestamp": time.time(),
                         "traceback": None
                     }
@@ -153,5 +164,13 @@ class PipelineEventMonitor:
             yield task_state
             
             if task_state["status"] in READY_STATES:
+                if task_state["result"] == "aborted":
+                    yield {
+                    "task_id": task_state["task_id"],
+                    "status": "ABORTED",
+                    "result": str(task_state["result"]),
+                    "timestamp": time.time(),
+                    "traceback": task_state["traceback"]
+                }
                 break
             await asyncio.sleep(interval)

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -66,12 +66,15 @@ class KedroGraphqlTask(AbortableTask):
         Returns:
             None: The return value of this handler is ignored.
         """
-        kedro_logger = logging.getLogger("kedro")
-        handler = KedroGraphQLLogHandler(
-            task_id, broker_url=self._app.conf["broker_url"])
-        # Tag handlers so we can cleanly remove only this task's handlers later.
-        handler.kedro_graphql_task_id = task_id
-        kedro_logger.addHandler(handler)
+        root_logger = logging.getLogger()
+        # Attach a task-scoped Redis stream handler so all propagated logs can be
+        # consumed by the `pipelineLogs` GraphQL subscription for this task.
+        stream_handler = KedroGraphQLLogHandler(
+            task_id,
+            broker_url=self._app.conf["broker_url"],
+        )
+        stream_handler.kedro_graphql_task_id = task_id
+        root_logger.addHandler(stream_handler)
         p = self.db.read(id=kwargs["id"])
         if p is None:
             logger.error(
@@ -106,8 +109,8 @@ class KedroGraphqlTask(AbortableTask):
             error_handler.setFormatter(formatter)
             info_handler.kedro_graphql_task_id = task_id
             error_handler.kedro_graphql_task_id = task_id
-            kedro_logger.addHandler(info_handler)
-            kedro_logger.addHandler(error_handler)
+            root_logger.addHandler(info_handler)
+            root_logger.addHandler(error_handler)
             # logger.info(
             # f"Storing tmp logs in {os.path.join(CONFIG['KEDRO_GRAPHQL_LOG_TMP_DIR'], task_id)}")
             logger.info(
@@ -243,10 +246,10 @@ class KedroGraphqlTask(AbortableTask):
             p.status[-1].task_result = str(retval)
             self.db.update(p)
 
-        # Clean up only this task's handlers from the kedro logger.
-        kedro_logger = logging.getLogger("kedro")
+        # Clean up only this task's handlers from the root logger.
+        root_logger = logging.getLogger()
         handlers_to_remove = [
-            h for h in list(kedro_logger.handlers)
+            h for h in list(root_logger.handlers)
             if getattr(h, "kedro_graphql_task_id", None) == task_id
         ]
         for handler in handlers_to_remove:
@@ -254,14 +257,17 @@ class KedroGraphqlTask(AbortableTask):
                 handler.flush()
             except Exception:
                 pass
+
             if isinstance(handler, KedroGraphQLLogHandler):
                 try:
-                    handler.broker.connection.delete(task_id)  # delete stream
+                    # Remove the Redis stream for this task and close connection.
+                    handler.broker.connection.delete(task_id)
                     handler.broker.connection.close()
                 except Exception:
                     pass
+
             handler.close()
-            kedro_logger.removeHandler(handler)
+            root_logger.removeHandler(handler)
 
         # Clear logs from temp_logs
         try:
@@ -285,6 +291,8 @@ def _run_pipeline_in_child_process(
     session_id: str,
     record_data: dict,
     pipeline_name: str,
+    task_id: str,
+    broker_url: str,
     result_queue,
 ):
     """Execute Kedro pipeline in a child process and report result via queue."""
@@ -293,6 +301,27 @@ def _run_pipeline_in_child_process(
         os.setsid()
     except OSError:
         pass
+
+    # Recreate stream handler in child process so Redis connection is process-local.
+    root_logger = logging.getLogger()
+    handlers_to_remove = [
+        h for h in list(root_logger.handlers)
+        if getattr(h, "kedro_graphql_task_id", None) == task_id
+        and isinstance(h, KedroGraphQLLogHandler)
+    ]
+    for handler in handlers_to_remove:
+        try:
+            handler.flush()
+        except Exception:
+            pass
+        handler.close()
+        root_logger.removeHandler(handler)
+
+    # Recreate the stream handler in the child so Redis connection state is
+    # owned by this process and safe to use after fork.
+    stream_handler = KedroGraphQLLogHandler(task_id, broker_url=broker_url)
+    stream_handler.kedro_graphql_task_id = task_id
+    root_logger.addHandler(stream_handler)
 
     try:
         # Recreate catalog in child process to avoid fork-unsafe connections with S3
@@ -505,6 +534,8 @@ def run_pipeline(self,
                     session.session_id,
                     record_data,
                     name,
+                    self.request.id,
+                    self._app.conf["broker_url"],
                     result_queue,
                 ),
             )

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -323,6 +323,23 @@ def _run_pipeline_in_child_process(
     stream_handler.kedro_graphql_task_id = task_id
     root_logger.addHandler(stream_handler)
 
+    # Track abort state so signal handlers can safely flush logs and call hooks.
+    abort_triggered = False
+    io = None
+    run_result = None
+
+    def handle_abort_signal(signum, frame):
+        """Handle SIGINT or SIGTERM by setting flag so logs and hooks are properly cleaned up."""
+        nonlocal abort_triggered
+        abort_triggered = True
+        # Raise KeyboardInterrupt to exit pipeline execution and trigger except block.
+        raise KeyboardInterrupt("Pipeline abort signal received")
+
+    # Register signal handlers so SIGINT/SIGTERM don't forcefully kill the child
+    # before logs and hooks are flushed.
+    signal.signal(signal.SIGINT, handle_abort_signal)
+    signal.signal(signal.SIGTERM, handle_abort_signal)
+
     try:
         # Recreate catalog in child process to avoid fork-unsafe connections with S3
         io = DataCatalog.from_config(catalog=catalog_config)
@@ -347,6 +364,27 @@ def _run_pipeline_in_child_process(
         )
         result_queue.put({"status": "success"})
     except BaseException as child_error:
+        # Always attempt to flush logs and call hooks even if pipeline was aborted or failed.
+        # This ensures persisted logs and S3 uploads happen before child exits.
+        if io is not None:
+            try:
+                # Flush all file handlers to ensure logs are written to disk.
+                for handler in list(root_logger.handlers):
+                    try:
+                        handler.flush()
+                    except Exception:
+                        pass
+                # Call after_pipeline_run hook so logs are saved to S3.
+                # For aborted pipelines, run_result may be None, but hook should still run.
+                hook_manager.hook.after_pipeline_run(
+                    run_params=record_data,
+                    run_result=run_result,
+                    pipeline=pipelines.get(pipeline_name, None),
+                    catalog=io,
+                )
+            except Exception as cleanup_error:
+                logger.warning(f"Error during log cleanup after abort: {cleanup_error}")
+        
         result_queue.put(
             {
                 "status": "error",

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 import tempfile
+import redis
 
 import pytest
 from kedro.framework.session import KedroSession
@@ -142,8 +143,8 @@ def mock_app(kedro_session):
 @pytest.fixture(scope='session')
 def celery_config():
     return {
-        'broker_url': 'redis://',
-        'result_backend': 'redis://',
+        'broker_url': 'redis://localhost:6379/15',
+        'result_backend': 'redis://localhost:6379/15',
         'result_extended': True,
         'worker_send_task_events': True,
         'task_send_sent_event': True,
@@ -153,6 +154,15 @@ def celery_config():
         'imports': ["kedro_graphql.tasks"]
 
     }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_test_redis():
+    """Ensure Redis keys created by tests are cleaned up before and after the session."""
+    connection = redis.Redis.from_url("redis://localhost:6379/15")
+    connection.flushdb()
+    yield
+    connection.flushdb()
 
 
 @pytest.fixture(scope='session')

--- a/src/tests/test_tasks.py
+++ b/src/tests/test_tasks.py
@@ -97,6 +97,8 @@ def test_run_pipeline_child_process_recreates_catalog():
                 session_id="test-session",
                 record_data={},
                 pipeline_name="test_pipeline",
+                task_id="test-task-id",
+                broker_url="redis://localhost:6379/0",
                 result_queue=result_queue
             )
             

--- a/src/tests/test_tasks.py
+++ b/src/tests/test_tasks.py
@@ -98,7 +98,7 @@ def test_run_pipeline_child_process_recreates_catalog():
                 record_data={},
                 pipeline_name="test_pipeline",
                 task_id="test-task-id",
-                broker_url="redis://localhost:6379/0",
+                broker_url="redis://localhost:6379/15",
                 result_queue=result_queue
             )
             

--- a/src/tests/utilities.py
+++ b/src/tests/utilities.py
@@ -13,4 +13,8 @@ def kedro_graphql_config():
     config["KEDRO_GRAPHQL_MONGO_DB_COLLECTION"] = "test_pipelines"
     config["KEDRO_GRAPHQL_MONGO_DB_NAME"] = "test_pipelines"
 
+    # Use an isolated Redis DB for tests so test runs do not pollute local/dev keys.
+    config["KEDRO_GRAPHQL_BROKER"] = "redis://localhost:6379/15"
+    config["KEDRO_GRAPHQL_CELERY_RESULT_BACKEND"] = "redis://localhost:6379/15"
+
     return config


### PR DESCRIPTION
## Added
- Documentation updates for log subscriptions, including custom log capture guidance and refreshed `pipelineLogs` examples

## Changed
- Pipeline subscription events now map Celery `SUCCESS` with result `aborted` to `ABORTED` so streamed status aligns with pipeline abort semantics
- Task-scoped log stream handlers are now attached to the root logger so propagated logs from Kedro and custom modules are captured consistently
- Task subprocess logging reinitializes stream handlers in the child process to keep Redis stream publishing process-local after fork

## Fixed
- `PipelineLogStream` now always closes async Redis connections with `aclose()` via `finally`, including subscription cancellation/disconnect paths
- `PipelineLogStream` terminal state detection now includes explicit `ABORTED` status
- Plugin registration logs now use correct labels for mutation and subscription plugin types
- `MongoBackend` now detects fork boundaries and recreates `MongoClient` per process to eliminate fork-safety warnings
- Celery config now sets `broker_connection_retry_on_startup=True` to suppress deprecation warning for future Celery 6.0 compatibility
- Child pipeline process now handles `SIGINT`/`SIGTERM` gracefully during abort so logs flush and hook-based log persistence still run before exit
- Tests now use an isolated Redis DB and flush it before/after the session to clean up Celery result keys and stream artifacts