### PR TITLE
migrate MongoBackend to Pymongo native async API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Added:
 
+- `run_sync` helper in `utils` to execute async backend coroutines from synchronous contexts (e.g. Celery task handlers) on a dedicated, fork-safe per-process event loop; raises `RuntimeError` if called from a running event loop
 - Test for catalog recreation in child process to prevent fork-safety issues with S3 and MongoDB connections
 - `DataSetInput.list_partitions` flag to support partition discovery in `readDatasets`
 - `readDatasets` schema coverage for partition discovery and partition-specific signed URL flows
@@ -19,6 +20,11 @@ Added:
 
 Changed:
 
+- `MongoBackend` migrated from synchronous PyMongo (`MongoClient`) to PyMongo's native async API (`AsyncMongoClient`); all backend methods (`startup`, `shutdown`, `read`, `list`, `create`, `update`, `delete`) are now async coroutines (Motor is deprecated as of May 14th, 2026)
+- GraphQL resolvers in `schema.py` now `await` backend methods directly, eliminating all `run_in_threadpool` delegation for database operations and providing true async I/O
+- `MongoBackend` now creates and caches one `AsyncMongoClient` per running event loop (keyed by process id) since an `AsyncMongoClient` is not thread safe and must be bound to a single event loop
+- Celery task handlers in `tasks.py` now invoke the async backend via `run_sync`
+- `MongoBackend.startup` now verifies connectivity with a `ping` command (warming the connection pool) and logs via `logger` instead of `print`
 - `PipelineEvent.timestamp` is now always a UTC ISO 8601 string (e.g. `"2026-05-14T12:55:52.779094"`). Live subscription events previously emitted a Unix epoch float from `time.time()` where as already-completed pipeline events previously passed the raw `datetime` object for `finished_at` so there was an inconsistency
 - `read_datasets` now supports returning `DataSet` for partition discovery requests
 - `KedroGraphqlTask` now inherits from Celery `AbortableTask`

--- a/src/kedro_graphql/asgi.py
+++ b/src/kedro_graphql/asgi.py
@@ -28,9 +28,9 @@ PERMISSIONS_CLASS = get_permissions(CONFIG.get("KEDRO_GRAPHQL_PERMISSIONS"))
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    app.backend.startup()
+    await app.backend.startup()
     yield
-    app.backend.shutdown()
+    await app.backend.shutdown()
 
 
 class KedroGraphQL(FastAPI):

--- a/src/kedro_graphql/backends/base.py
+++ b/src/kedro_graphql/backends/base.py
@@ -7,36 +7,36 @@ from kedro_graphql.models import Pipeline
 class BaseBackend(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
-    def startup(self, **kwargs):
+    async def startup(self, **kwargs):
         """Startup hook."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def shutdown(self, **kwargs):
+    async def shutdown(self, **kwargs):
         """Shutdown hook."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def read(self, id: uuid.UUID = None, task_id: str = None):
+    async def read(self, id: uuid.UUID = None, task_id: str = None):
         """Load a pipeline by id"""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def list(self, cursor: uuid.UUID = None, limit: int = None, filter: str = None, sort: str = None):
+    async def list(self, cursor: uuid.UUID = None, limit: int = None, filter: str = None, sort: str = None):
         """List pipelines using cursor pagination"""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def create(self, pipeline: Pipeline):
+    async def create(self, pipeline: Pipeline):
         """Save a pipeline"""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def update(self, pipeline: Pipeline):
+    async def update(self, pipeline: Pipeline):
         """Update a pipeline"""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def delete(self, id: uuid.UUID = None):
+    async def delete(self, id: uuid.UUID = None):
         """Delete a pipeline"""
         raise NotImplementedError

--- a/src/kedro_graphql/backends/mongodb.py
+++ b/src/kedro_graphql/backends/mongodb.py
@@ -1,48 +1,77 @@
 import ast
+import asyncio
 import json
 import os
+import threading
 import uuid
+import weakref
 
 from bson.objectid import ObjectId
-from pymongo import MongoClient
+from pymongo import AsyncMongoClient
 
+from kedro_graphql.logs.logger import logger
 from kedro_graphql.models import Pipeline
 
 from .base import BaseBackend
 
 
 class MongoBackend(BaseBackend):
+    """MongoDB backend built on PyMongo's native async API (``AsyncMongoClient``).
+
+    All database operations are coroutines, so resolvers can ``await`` them directly
+    without delegating blocking I/O to a thread pool. An ``AsyncMongoClient`` is not
+    thread safe and may only be used by a single event loop, so one client is created
+    and cached per running event loop. Clients are also keyed by process id so the
+    backend remains safe across ``fork`` (e.g. Celery's prefork worker pool).
+    """
 
     def __init__(self, uri=None, db=None, collection="pipelines"):
         self.uri = uri
         self.db_name = db
-        self.client = MongoClient(self.uri)
-        self.db = self.client[self.db_name]
-        # Track process id to detect fork boundaries.
-        self.client_pid = os.getpid()
         self.collection = collection
+        self._pid = os.getpid()
+        # Map the running event loop to its own AsyncMongoClient. Weak keys allow
+        # clients to be garbage collected once their event loop is gone.
+        self._clients: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncMongoClient]" = (
+            weakref.WeakKeyDictionary()
+        )
+        self._clients_lock = threading.Lock()
 
-    def startup(self, **kwargs):
-        """Startup hook."""
-        # Recreate client if this process was forked after backend initialization.
-        if self.client_pid != os.getpid():
-            self.client.close()
-            self.client = MongoClient(self.uri)
-            self.db = self.client[self.db_name]
-            self.client_pid = os.getpid()
-        print("Connected to the MongoDB database!")
+    def _get_client(self) -> AsyncMongoClient:
+        """Return an ``AsyncMongoClient`` bound to the current running event loop."""
+        loop = asyncio.get_running_loop()
+        pid = os.getpid()
+        with self._clients_lock:
+            if pid != self._pid:
+                # Process was forked; clients are bound to the parent's event loops
+                # and must not be reused.
+                self._clients = weakref.WeakKeyDictionary()
+                self._pid = pid
+            client = self._clients.get(loop)
+            if client is None:
+                client = AsyncMongoClient(self.uri)
+                self._clients[loop] = client
+            return client
 
-    def shutdown(self, **kwargs):
+    def _get_collection(self):
+        """Return the configured collection bound to the current event loop."""
+        return self._get_client()[self.db_name][self.collection]
+
+    async def startup(self, **kwargs):
+        """Startup hook. Verifies connectivity and warms the connection pool."""
+        await self._get_client().admin.command("ping")
+        logger.info("Connected to the MongoDB database!")
+
+    async def shutdown(self, **kwargs):
         """Shutdown hook."""
-        self.client.close()
+        loop = asyncio.get_running_loop()
+        with self._clients_lock:
+            client = self._clients.pop(loop, None)
+        if client is not None:
+            await client.close()
 
-    def list(self, cursor: uuid.UUID = None, limit=10, filter="", sort=""):
-        # Recreate client if this method is running in a different process.
-        if self.client_pid != os.getpid():
-            self.client.close()
-            self.client = MongoClient(self.uri)
-            self.db = self.client[self.db_name]
-            self.client_pid = os.getpid()
+    async def list(self, cursor: uuid.UUID = None, limit=10, filter="", sort=""):
+        collection = self._get_collection()
 
         query = {}
         if len(filter) > 0:
@@ -56,36 +85,31 @@ class MongoBackend(BaseBackend):
                 sort = ast.literal_eval(sort)
                 # Validate that sort is a list of tuples like [('created_at', -1)]
                 if isinstance(sort, list) and all(isinstance(i, tuple) and len(i) == 2 for i in sort):
-                    raw = self.db[self.collection].find(query).sort(sort).limit(limit)
+                    raw = collection.find(query).sort(sort).limit(limit)
                 else:
                     raise ValueError(
                         "Sort parameter should be a list of tuples like [('field', order)]")
             except (ValueError, SyntaxError) as e:
                 raise ValueError(f"Invalid sort parameter format: {e}")
         else:
-            raw = self.db[self.collection].find(query).limit(limit)
+            raw = collection.find(query).limit(limit)
 
         results = []
-        for r in raw:
+        async for r in raw:
             r["id"] = str(r["_id"])
             p = Pipeline.decode(r)
             results.append(p)
         return results
 
-    def read(self, id: uuid.UUID = None, task_id: str = None):
+    async def read(self, id: uuid.UUID = None, task_id: str = None):
         """Load a pipeline by id or task_id"""
-        # Recreate client if this method is running in a different process.
-        if self.client_pid != os.getpid():
-            self.client.close()
-            self.client = MongoClient(self.uri)
-            self.db = self.client[self.db_name]
-            self.client_pid = os.getpid()
+        collection = self._get_collection()
 
         if task_id:
-            r = self.db[self.collection].find_one(
+            r = await collection.find_one(
                 {"status": {"$elemMatch": {"task_id": task_id}}})
         else:
-            r = self.db[self.collection].find_one({"_id": ObjectId(id)})
+            r = await collection.find_one({"_id": ObjectId(id)})
 
         if r:
             r["id"] = str(r["_id"])
@@ -94,51 +118,36 @@ class MongoBackend(BaseBackend):
         else:
             return None
 
-    def create(self, pipeline: Pipeline):
+    async def create(self, pipeline: Pipeline):
         """Save a pipeline"""
-        # Recreate client if this method is running in a different process.
-        if self.client_pid != os.getpid():
-            self.client.close()
-            self.client = MongoClient(self.uri)
-            self.db = self.client[self.db_name]
-            self.client_pid = os.getpid()
+        collection = self._get_collection()
 
         values = pipeline.encode()
         values.pop("id")  # we dont have an id yet, we will get it after insert
-        created = self.db[self.collection].insert_one(values)
-        created = self.db[self.collection].find_one({"_id": created.inserted_id})
+        created = await collection.insert_one(values)
+        created = await collection.find_one({"_id": created.inserted_id})
         created["id"] = str(created["_id"])
         p = Pipeline.decode(created)
         return p
 
-    def update(self, pipeline: Pipeline = None):
+    async def update(self, pipeline: Pipeline = None):
         """Update a pipeline"""
-        # Recreate client if this method is running in a different process.
-        if self.client_pid != os.getpid():
-            self.client.close()
-            self.client = MongoClient(self.uri)
-            self.db = self.client[self.db_name]
-            self.client_pid = os.getpid()
+        collection = self._get_collection()
 
         id = ObjectId(pipeline.id)
         filter = {'_id': id}
         values = pipeline.encode()
         values.pop("id")  # we dont want to update the id
         newvalues = {"$set": values}
-        self.db[self.collection].update_one(filter, newvalues)
+        await collection.update_one(filter, newvalues)
 
-        p = self.read(id=id)
+        p = await self.read(id=id)
 
         return p
 
-    def delete(self, id: uuid.UUID = None):
+    async def delete(self, id: uuid.UUID = None):
         """Delete a pipeline using id"""
-        # Recreate client if this method is running in a different process.
-        if self.client_pid != os.getpid():
-            self.client.close()
-            self.client = MongoClient(self.uri)
-            self.db = self.client[self.db_name]
-            self.client_pid = os.getpid()
+        collection = self._get_collection()
 
-        self.db[self.collection].delete_one({"_id": ObjectId(id)})
+        await collection.delete_one({"_id": ObjectId(id)})
         return id

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -13,7 +13,6 @@ from celery.contrib.abortable import AbortableAsyncResult
 from celery.states import UNREADY_STATES, READY_STATES
 from fastapi.encoders import jsonable_encoder
 from kedro.framework.project import pipelines
-from starlette.concurrency import run_in_threadpool
 from strawberry.extensions import SchemaExtension
 from strawberry.permission import PermissionExtension
 from strawberry.tools import merge_types
@@ -365,8 +364,7 @@ class Query:
     @strawberry.field(description="Get a pipeline instance.", extensions=[PermissionExtension(permissions=[PERMISSIONS_CLASS(action="read_pipeline")]), PipelineExtension()])
     async def read_pipeline(self, id: str, info: Info) -> Pipeline:
         try:
-            # Run blocking database read in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+            p = await info.context["request"].app.backend.read(id=id)
             if p is None:
                 raise InvalidPipeline(
                     f"Pipeline {id} does not exist in the project.")
@@ -385,9 +383,7 @@ class Query:
         else:
             pipe_id = "000000000000000000000000"  # unix epoch Jan 1, 1970 as objectId
 
-        # Run blocking database list in thread pool
-        results = await run_in_threadpool(
-            info.context["request"].app.backend.list,
+        results = await info.context["request"].app.backend.list(
             cursor=pipe_id, limit=limit + 1, filter=filter, sort=sort)
         if len(results) > limit:
 
@@ -429,8 +425,7 @@ class Query:
                 f"expires_in_sec cannot be greater than {CONFIG['KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC']} seconds ({CONFIG['KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC'] // 3600} hours)")
 
         urls = []
-        # Run blocking database read in thread pool
-        p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+        p = await info.context["request"].app.backend.read(id=id)
 
         catalog = {d.name: d for d in p.data_catalog}
 
@@ -514,12 +509,10 @@ class Mutation:
                                            task_id=None,
                                            task_name=None))
             logger.info(f'Staging pipeline {p.name}')
-            # Run blocking database create in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.create, p)
+            p = await info.context["request"].app.backend.create(p)
             if unique_paths:
                 p = generate_unique_paths(p, unique_paths)
-                # Run blocking database update in thread pool
-                p = await run_in_threadpool(info.context["request"].app.backend.update, p)
+                p = await info.context["request"].app.backend.update(p)
 
             logger.info(
                 f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=create_pipeline, id={p.id}, name={p.name}, state=STAGED")
@@ -533,12 +526,10 @@ class Mutation:
                                            task_id=None,
                                            task_name=str(run_pipeline)))
 
-            # Run blocking database create in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.create, p)
+            p = await info.context["request"].app.backend.create(p)
             if unique_paths:
                 p = generate_unique_paths(p, unique_paths)
-                # Run blocking database update in thread pool
-                p = await run_in_threadpool(info.context["request"].app.backend.update, p)
+                p = await info.context["request"].app.backend.update(p)
 
             result = run_pipeline.delay(
                 id=str(p.id),
@@ -558,8 +549,7 @@ class Mutation:
     async def update_pipeline(self, id: str, pipeline: PipelineInput, info: Info, unique_paths: Optional[List[str]] = None) -> Pipeline:
 
         try:
-            # Run blocking database read in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+            p = await info.context["request"].app.backend.read(id=id)
             if p is None:
                 raise InvalidPipeline(
                     f"Pipeline {id} does not exist in the project.")
@@ -587,8 +577,7 @@ class Mutation:
             ).abort()
             p.status[-1].state = State.ABORTING
             p.status[-1].abort_requested_at = datetime.now()
-            # Run blocking database update in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.update, p)
+            p = await info.context["request"].app.backend.update(p)
             logger.info(
                 f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=abort_pipeline, id={p.id}, name={p.name}, task_id={p.status[-1].task_id}")
             return p
@@ -627,8 +616,7 @@ class Mutation:
                 p = generate_unique_paths(p, unique_paths)
 
             # Update pipeline in backend before running task
-            # Run blocking database update in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.update, p)
+            p = await info.context["request"].app.backend.update(p)
 
             serial = p.encode(encoder="kedro")
 
@@ -657,8 +645,7 @@ class Mutation:
             logger.info(f'Staging pipeline {p.name}')
         if unique_paths:
             p = generate_unique_paths(p, unique_paths)
-        # Run blocking database update in thread pool
-        p = await run_in_threadpool(info.context["request"].app.backend.update, p)
+        p = await info.context["request"].app.backend.update(p)
         logger.info(
             f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=update_pipeline, id={p.id}, name={p.name}")
 
@@ -667,16 +654,14 @@ class Mutation:
     @strawberry.mutation(description="Delete a pipeline.", extensions=[PermissionExtension(permissions=[PERMISSIONS_CLASS(action="delete_pipeline")]), PipelineExtension()])
     async def delete_pipeline(self, id: str, info: Info) -> Optional[Pipeline]:
         try:
-            # Run blocking database read in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+            p = await info.context["request"].app.backend.read(id=id)
             if p is None:
                 raise InvalidPipeline(
                     f"Pipeline {id} does not exist in the project.")
         except Exception as e:
             raise InvalidPipeline(f"Error retrieving pipeline {id}: {e}")
 
-        # Run blocking database delete in thread pool
-        await run_in_threadpool(info.context["request"].app.backend.delete, id=id)
+        await info.context["request"].app.backend.delete(id=id)
         logger.info(f'Deleted {p.name} pipeline with id: ' + str(id))
         return p
 
@@ -703,8 +688,7 @@ class Mutation:
             raise ValueError(
                 f"expires_in_sec cannot be greater than {CONFIG['KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC']} seconds ({CONFIG['KEDRO_GRAPHQL_SIGNED_URL_MAX_EXPIRES_IN_SEC'] // 3600} hours)")
         urls = []
-        # Run blocking database read in thread pool
-        p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+        p = await info.context["request"].app.backend.read(id=id)
 
         if p.status[-1].state.value != "STAGED":
             raise ValueError(
@@ -743,8 +727,7 @@ class Subscription:
         """Subscribe to pipeline events.
         """
         try:
-            # Run blocking database read in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+            p = await info.context["request"].app.backend.read(id=id)
             if p is None:
                 raise InvalidPipeline(
                     f"Pipeline {id} does not exist in the project.")
@@ -754,8 +737,7 @@ class Subscription:
         while (not p.status[-1].task_id):
             # Wait for the task to be assigned a task_id
             await asyncio.sleep(0.1)
-            # Run blocking database read in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+            p = await info.context["request"].app.backend.read(id=id)
 
         if p and p.status[-1].state.value not in READY_STATES:
             async for e in PipelineEventMonitor(app=info.context["request"].app.celery_app, task_id=p.status[-1].task_id).start(interval=interval):
@@ -776,8 +758,7 @@ class Subscription:
     async def pipeline_logs(self, id: str, info: Info) -> AsyncGenerator[PipelineLogMessage, None]:
         """Subscribe to pipeline logs."""
         try:
-            # Run blocking database read in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+            p = await info.context["request"].app.backend.read(id=id)
             if p is None:
                 raise InvalidPipeline(
                     f"Pipeline {id} does not exist in the project.")
@@ -787,8 +768,7 @@ class Subscription:
         while (not p.status[-1].task_id):
             # Wait for the task to be assigned a task_id
             await asyncio.sleep(0.1)
-            # Run blocking database read in thread pool
-            p = await run_in_threadpool(info.context["request"].app.backend.read, id=id)
+            p = await info.context["request"].app.backend.read(id=id)
 
         if p:
             stream = await PipelineLogStream().create(task_id=p.status[-1].task_id, broker_url=info.context["request"].app.config["KEDRO_GRAPHQL_BROKER"])

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -20,7 +20,7 @@ from kedro.io import AbstractDataset, DataCatalog
 from omegaconf import OmegaConf
 
 from kedro_graphql.logs.logger import KedroGraphQLLogHandler
-from kedro_graphql.utils import add_param_to_feed_dict
+from kedro_graphql.utils import add_param_to_feed_dict, run_sync
 from kedro_graphql.runners import init_runner
 from kedro_graphql.models import PipelineInput, ParameterInput, Pipeline
 
@@ -75,7 +75,7 @@ class KedroGraphqlTask(AbortableTask):
         )
         stream_handler.kedro_graphql_task_id = task_id
         root_logger.addHandler(stream_handler)
-        p = self.db.read(id=kwargs["id"])
+        p = run_sync(self.db.read(id=kwargs["id"]))
         if p is None:
             logger.error(
                 f"Pipeline id={kwargs['id']} not found in backend during before_start; task_id={task_id}")
@@ -84,7 +84,7 @@ class KedroGraphqlTask(AbortableTask):
         p.status[-1].task_id = task_id
         p.status[-1].task_args = json.dumps(args)
         p.status[-1].task_kwargs = json.dumps(kwargs)
-        self.db.update(p)
+        run_sync(self.db.update(p))
 
         try:
             # Create info and error handlers for the run
@@ -137,7 +137,7 @@ class KedroGraphqlTask(AbortableTask):
                 # Save metadata to S3
                 AbstractDataset.from_config(gql_meta.name, json.loads(
                     gql_meta.config)).save(p.serialize())
-                p = self.db.update(p)
+                p = run_sync(self.db.update(p))
 
                 logger.info(
                     f"Capturing pipeline metadata in {os.path.join(log_path_prefix,f'year={today.year}',f'month={today.month}',f'day={today.day}',str(p.id),'meta.json')}")
@@ -167,13 +167,13 @@ class KedroGraphqlTask(AbortableTask):
             None: The return value of this handler is ignored.
         """
 
-        p = self.db.read(id=kwargs["id"])
+        p = run_sync(self.db.read(id=kwargs["id"]))
         if p is None:
             return
         if p.status[-1].state in {State.ABORTING, State.ABORTED}:
             return
         p.status[-1].state = State.SUCCESS
-        self.db.update(p)
+        run_sync(self.db.update(p))
 
     def on_retry(self, exc, task_id, args, kwargs, einfo):
         """Retry handler.
@@ -191,12 +191,12 @@ class KedroGraphqlTask(AbortableTask):
             None: The return value of this handler is ignored.
         """
 
-        p = self.db.read(id=kwargs["id"])
+        p = run_sync(self.db.read(id=kwargs["id"]))
         if p is not None:
             p.status[-1].state = State.RETRY
             p.status[-1].task_exception = str(exc)
             p.status[-1].task_einfo = str(einfo)
-            self.db.update(p)
+            run_sync(self.db.update(p))
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Error handler.
@@ -214,14 +214,14 @@ class KedroGraphqlTask(AbortableTask):
             None: The return value of this handler is ignored.
         """
 
-        p = self.db.read(id=kwargs["id"])
+        p = run_sync(self.db.read(id=kwargs["id"]))
         if p is not None:
             if p.status[-1].state in {State.ABORTING, State.ABORTED}:
                 return
             p.status[-1].state = State.FAILURE
             p.status[-1].task_exception = str(exc)
             p.status[-1].task_einfo = str(einfo)
-            self.db.update(p)
+            run_sync(self.db.update(p))
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """Handler called after the task returns.
@@ -240,11 +240,11 @@ class KedroGraphqlTask(AbortableTask):
 
         finished_at = datetime.now()
 
-        p = self.db.read(id=kwargs["id"])
+        p = run_sync(self.db.read(id=kwargs["id"]))
         if p is not None:
             p.status[-1].finished_at = finished_at
             p.status[-1].task_result = str(retval)
-            self.db.update(p)
+            run_sync(self.db.update(p))
 
         # Clean up only this task's handlers from the root logger.
         root_logger = logging.getLogger()
@@ -412,7 +412,7 @@ def run_pipeline(self,
 
         hook_manager = session._hook_manager
 
-        p = self.db.read(id=id)
+        p = run_sync(self.db.read(id=id))
         if p is None:
             logger.warning(
                 "Pipeline id=%s not found in backend during run_pipeline; task_id=%s",
@@ -421,7 +421,7 @@ def run_pipeline(self,
             )
             return
         p.status[-1].session = session.session_id
-        self.db.update(p)
+        run_sync(self.db.update(p))
 
         # If modified data catalog object with gql_meta and gql_logs datasets exists, use it
         if getattr(self, "kedro_graphql_pipeline", None):
@@ -551,9 +551,9 @@ def run_pipeline(self,
                     node_namespace=node_namespace,
                 )
 
-            p = self.db.read(id=id)
+            p = run_sync(self.db.read(id=id))
             p.status[-1].filtered_nodes = [node.name for node in filtered_pipeline.nodes]
-            self.db.update(p)
+            run_sync(self.db.update(p))
 
             # Use Celery's multiprocessing library (billiard) instead of multiprocessing
             # to avoid AssertionError: daemonic processes are not allowed to have children
@@ -674,11 +674,11 @@ def run_pipeline(self,
                 logger.warning("Child process pid=%s finished without posting a result", child.pid)
 
             if self.is_aborted():
-                p = self.db.read(id=id)
+                p = run_sync(self.db.read(id=id))
                 if p is not None:
                     p.status[-1].state = State.ABORTED
                     p.status[-1].abort_completed_at = datetime.now()
-                    self.db.update(p)
+                    run_sync(self.db.update(p))
                 return "aborted"
 
             if child_result.get("status") != "success":

--- a/src/kedro_graphql/utils.py
+++ b/src/kedro_graphql/utils.py
@@ -1,13 +1,63 @@
+import asyncio
 import gql
 import json
+import os
+import threading
 from functools import reduce
 from graphql.language import print_ast
 from importlib_resources import files
-from typing import Any, Optional
+from typing import Any, Awaitable, Optional, TypeVar
 from .models import Pipeline
 from urllib.parse import urlparse
 from .logs.logger import logger
 from .exceptions import DataSetConfigError
+
+T = TypeVar("T")
+
+_async_loops_lock = threading.Lock()
+_async_loops: dict[int, asyncio.AbstractEventLoop] = {}
+
+
+def run_sync(coro: Awaitable[T]) -> T:
+    """Run an async coroutine from a synchronous context and return its result.
+
+    PyMongo's ``AsyncMongoClient`` is not thread safe and may only be used by a
+    single event loop. Synchronous callers (e.g. Celery task handlers and scripts)
+    therefore execute backend coroutines on a dedicated, persistent event loop
+    running on a background thread. One loop is maintained per process so the
+    helper remains safe across ``fork`` (Celery's prefork worker pool).
+
+    Args:
+        coro: The coroutine to execute.
+
+    Returns:
+        The result of awaiting ``coro``.
+
+    Raises:
+        RuntimeError: If called from a thread with a running event loop;
+            async callers must ``await`` the coroutine directly.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        raise RuntimeError(
+            "run_sync() called from a running event loop; await the coroutine directly instead.")
+
+    pid = os.getpid()
+    with _async_loops_lock:
+        loop = _async_loops.get(pid)
+        if loop is None or loop.is_closed():
+            loop = asyncio.new_event_loop()
+            thread = threading.Thread(
+                target=loop.run_forever,
+                name=f"kedro-graphql-async-{pid}",
+                daemon=True,
+            )
+            thread.start()
+            _async_loops[pid] = loop
+    return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
 
 def build_graphql_query(

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -20,6 +20,7 @@ from kedro_graphql.models import (
     Tag,
 )
 from kedro_graphql.tasks import run_pipeline
+from kedro_graphql.utils import run_sync
 from fastapi.middleware.cors import CORSMiddleware
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import bootstrap_project
@@ -271,7 +272,7 @@ def mock_pipeline(mock_celery_session_app,
     )
 
     p.created_at = datetime.now()
-    p = mock_app.backend.create(p)
+    p = run_sync(mock_app.backend.create(p))
 
     serial = p.serialize()
 
@@ -284,7 +285,7 @@ def mock_pipeline(mock_celery_session_app,
 
     print(f'Starting {p.name} pipeline with task_id: ' + str(result.id))
     p.status[-1].task_id = result.id
-    p = mock_app.backend.update(p)
+    p = run_sync(mock_app.backend.update(p))
     return p
 
 
@@ -312,7 +313,7 @@ def mock_pipeline_staged(mock_app):
     )
 
     p.created_at = datetime.now()
-    p = mock_app.backend.create(p)
+    p = run_sync(mock_app.backend.create(p))
     return p
 
 
@@ -340,7 +341,7 @@ def mock_pipeline2(mock_app, tmp_path, mock_text_in, mock_text_out):
     )
 
     p.created_at = datetime.now()
-    p = mock_app.backend.create(p)
+    p = run_sync(mock_app.backend.create(p))
 
     serial = p.serialize()
 
@@ -353,7 +354,7 @@ def mock_pipeline2(mock_app, tmp_path, mock_text_in, mock_text_out):
 
     print(f'Starting {p.name} pipeline with task_id: ' + str(result.id))
     p.status[-1].task_id = result.id
-    p = mock_app.backend.update(p)
+    p = run_sync(mock_app.backend.update(p))
     return p
 
 
@@ -421,7 +422,7 @@ def mock_example01(mock_app, mock_timestamped_partitioned_dir, mock_text_in):
     )
 
     p.created_at = datetime.now()
-    p = mock_app.backend.create(p)
+    p = run_sync(mock_app.backend.create(p))
     return p
 
 
@@ -430,4 +431,9 @@ def delete_pipeline_collection(mock_app):
     # Will be executed before the first test
     yield
     # Will be executed after the last test
-    mock_app.backend.db[mock_app.config["KEDRO_GRAPHQL_MONGO_DB_NAME"]].drop()
+
+    async def _drop():
+        db = mock_app.backend._get_collection().database
+        await db[mock_app.config["KEDRO_GRAPHQL_MONGO_DB_NAME"]].drop()
+
+    run_sync(_drop())

--- a/src/tests/runners/argo/conftest.py
+++ b/src/tests/runners/argo/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 from kedro_graphql.models import DataSet, Parameter, Pipeline, Tag
 from kedro_graphql.tasks import run_pipeline
+from kedro_graphql.utils import run_sync
 
 IN_DEV = True
 REASON = "Argo runner in development"
@@ -125,7 +126,7 @@ def mock_pipeline_argo(mock_app, s3_object, s3_client):
     )
 
     print(f'Starting {p.name} pipeline with task_id: ' + str(p.task_id))
-    p = mock_app.backend.create(p)
+    p = run_sync(mock_app.backend.create(p))
     yield p
     # cleanup
     s3_client.remove_object("my-bucket", out_fname)

--- a/src/tests/test_backends.py
+++ b/src/tests/test_backends.py
@@ -1,22 +1,27 @@
+import pytest
+
 from kedro_graphql.models import State
 
 
-def test_backend_create(mock_app, mock_pipeline_no_task):
-    p = mock_app.backend.create(mock_pipeline_no_task)
+@pytest.mark.asyncio
+async def test_backend_create(mock_app, mock_pipeline_no_task):
+    p = await mock_app.backend.create(mock_pipeline_no_task)
     assert p.id is not None
     p.id = None
     assert p == mock_pipeline_no_task
 
 
-def test_backend_update(mock_app, mock_pipeline_no_task):
-    p = mock_app.backend.create(mock_pipeline_no_task)
+@pytest.mark.asyncio
+async def test_backend_update(mock_app, mock_pipeline_no_task):
+    p = await mock_app.backend.create(mock_pipeline_no_task)
     p.name = "example01"
-    p = mock_app.backend.update(p)
+    p = await mock_app.backend.update(p)
     assert p.name == "example01"
 
 
-def test_backend_update_status(mock_app, mock_pipeline_no_task):
-    p = mock_app.backend.create(mock_pipeline_no_task)
+@pytest.mark.asyncio
+async def test_backend_update_status(mock_app, mock_pipeline_no_task):
+    p = await mock_app.backend.create(mock_pipeline_no_task)
     p.status[-1].state = State.STARTED
-    p = mock_app.backend.update(p)
+    p = await mock_app.backend.update(p)
     assert p.status[-1].state == State.STARTED

--- a/src/tests/test_schema_extensions.py
+++ b/src/tests/test_schema_extensions.py
@@ -122,7 +122,7 @@ class TestSchemaExtensions:
                 assert not c["filepath"].startswith(prefix)
 
         # check backend to make sure filepaths are unmasked
-        pipeline = mock_app.backend.read(id=p.id)
+        pipeline = await mock_app.backend.read(id=p.id)
         for d in pipeline.data_catalog:
             c = json.loads(d.config)
             if c.get("filepath"):

--- a/src/tests/test_schema_mutation.py
+++ b/src/tests/test_schema_mutation.py
@@ -430,7 +430,7 @@ class TestSchemaMutations:
         assert started_event["id"] == pipeline_id
         assert started_event["status"] in UNREADY_STATES
         assert started_event["taskId"] is not None
-        p = mock_app.backend.read(id=pipeline_id)
+        p = await mock_app.backend.read(id=pipeline_id)
         assert p is not None
 
         # Send an abort request
@@ -476,7 +476,7 @@ class TestSchemaMutations:
         assert events[-1]["status"] == "SUCCESS"
         assert str(events[-1]["result"]).lower() == "aborted"
 
-        updated = mock_app.backend.read(id=pipeline_id)
+        updated = await mock_app.backend.read(id=pipeline_id)
         assert updated is not None
         assert updated.status[-1].state == State.ABORTED
 
@@ -545,8 +545,8 @@ class TestSchemaMutations:
             assert not result.errors
             if result.data["pipeline"]["status"] == "SUCCESS":
                 break
-        dataset_names = {ds.name for ds in mock_app.backend.read(
-            create_pipeline_resp.data["createPipeline"]["id"]).data_catalog}
+        dataset_names = {ds.name for ds in (await mock_app.backend.read(
+            create_pipeline_resp.data["createPipeline"]["id"])).data_catalog}
 
         assert "gql_meta" in dataset_names
         assert "gql_logs" in dataset_names
@@ -594,8 +594,8 @@ class TestSchemaMutations:
                 break
 
         # Make sure only nodes specified in "slices" were run
-        assert mock_app.backend.read(create_pipeline_resp.data["createPipeline"]
-                                     ["id"]).status[-1].filtered_nodes == ["uppercase_node", "reverse_node"]
+        assert (await mock_app.backend.read(create_pipeline_resp.data["createPipeline"]
+                                            ["id"])).status[-1].filtered_nodes == ["uppercase_node", "reverse_node"]
         create_pipeline_resp.errors is None
 
     @pytest.mark.asyncio
@@ -640,8 +640,8 @@ class TestSchemaMutations:
                 break
 
         # Make sure only timestamp_node was run because the file does not exist (did not write to it in conftest.py)
-        assert mock_app.backend.read(create_pipeline_resp.data["createPipeline"]
-                                     ["id"]).status[-1].filtered_nodes == ["timestamp_node", "timestamp_partitions_node"]
+        assert (await mock_app.backend.read(create_pipeline_resp.data["createPipeline"]
+                                            ["id"])).status[-1].filtered_nodes == ["timestamp_node", "timestamp_partitions_node"]
         create_pipeline_resp.errors is None
 
     @pytest.mark.asyncio

--- a/src/tests/test_tasks.py
+++ b/src/tests/test_tasks.py
@@ -48,7 +48,7 @@ async def test_run_pipeline(mock_app,
                                task_name=None)]
     )
 
-    p = mock_app.backend.create(p)
+    p = await mock_app.backend.create(p)
     serial = p.serialize()
 
     result = run_pipeline.delay(


### PR DESCRIPTION
This PR migrates the MongoDB backend from synchronous PyMongo (MongoClient) to PyMongo’s native async API (AsyncMongoClient), so GraphQL resolvers can await database calls directly instead of wrapping blocking I/O in `run_in_threadpool`. Celery task handlers still run synchronously, so they use a small `run_sync` helper that runs backend coroutines on a dedicated background event loop in each worker process. Because async Mongo clients must be tied to a single event loop, the backend creates and reuses one client per loop (and resets after fork), replacing the old copy-pasted fork-handling logic in every method. Startup now pings Mongo to verify connectivity before serving traffic. Behavior and tests are unchanged; the main benefit is better concurrency under load and alignment with Mongo’s supported async driver path as Motor is deprecated