### PR TITLE
Codex/feat resolve pipeline config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Changed:
 
 Fixed:
 
+- Pipeline catalogs are now resolved against the full registered pipeline before persistence, including Kedro dataset factory patterns, while sliced-run validation only checks the selected execution DAG
+- Custom runners can declare `supports_memory_datasets = False` to require persistent configurations for every dataset in the selected execution DAG
 - Catalog now recreated in child process to prevent fork-safety errors with S3 (`TextDataset` with S3 protocol) and MongoDB connections; connections are now created fresh in the child process instead of inherited from parent
 - Mismatch in types `ObjectId` and `str` caused the `readTemplates` query to always fail
 - Celery task callback null-safety in `before_start`, `on_success`, and `on_retry` when pipeline records are missing

--- a/src/kedro_graphql/asgi.py
+++ b/src/kedro_graphql/asgi.py
@@ -148,7 +148,7 @@ class KedroGraphQL(FastAPI):
                 for n in pipeline_names:
 
                     pipeline_input = PipelineInput.from_event(
-                        name=n, event=event, state="READY"
+                        name=n, event=event, state="STAGED"
                     )
 
                     q_create = build_graphql_query(

--- a/src/kedro_graphql/exceptions.py
+++ b/src/kedro_graphql/exceptions.py
@@ -10,3 +10,9 @@ class DataSetError(Exception):
     """
 
     pass
+
+
+class InvalidPipeline(Exception):
+    """Raised when a pipeline cannot be staged or executed safely."""
+
+    pass

--- a/src/kedro_graphql/hooks.py
+++ b/src/kedro_graphql/hooks.py
@@ -7,18 +7,11 @@ from kedro.pipeline import Pipeline
 from kedro_graphql.logs.logger import logger
 
 from .config import load_config
+from .exceptions import InvalidPipeline
 
 CONFIG = load_config()
 
 logger.debug("configuration loaded by {s}".format(s=__name__))
-
-
-class InvalidPipeline(Exception):
-    """Custom exception for invalid pipeline."""
-
-    def __init__(self, message="The pipeline is invalid"):
-        self.message = message
-        super().__init__(self.message)
 
 
 class DataValidationHooks:

--- a/src/kedro_graphql/models.py
+++ b/src/kedro_graphql/models.py
@@ -537,7 +537,10 @@ class PipelineInput:
             p = jsonable_encoder(self)
             if self.data_catalog:
                 p["data_catalog"] = [
-                    dataset.encode(encoder="graphql") for dataset in self.data_catalog
+                    (dataset if isinstance(dataset, DataSetInput) else DataSetInput(**dataset)).encode(
+                        encoder="graphql"
+                    )
+                    for dataset in self.data_catalog
                 ]
             p = {to_camel_case(k): v for k, v in p.items()}
             # make sure parameter types are uppercase

--- a/src/kedro_graphql/models.py
+++ b/src/kedro_graphql/models.py
@@ -535,6 +535,10 @@ class PipelineInput:
             return jsonable_encoder(self)
         elif encoder == "graphql":
             p = jsonable_encoder(self)
+            if self.data_catalog:
+                p["data_catalog"] = [
+                    dataset.encode(encoder="graphql") for dataset in self.data_catalog
+                ]
             p = {to_camel_case(k): v for k, v in p.items()}
             # make sure parameter types are uppercase
             if p.get("parameters", None):

--- a/src/kedro_graphql/models.py
+++ b/src/kedro_graphql/models.py
@@ -22,6 +22,7 @@ from kedro_graphql.exceptions import DataSetConfigError
 
 from .config import load_config
 from .logs.logger import logger
+from .pipeline_config import normalize_pipeline_config
 # from .permissions import get_permissions
 
 
@@ -364,6 +365,11 @@ class PipelineTemplate:
     kedro_catalog: strawberry.Private[dict]
     kedro_parameters: strawberry.Private[dict]
 
+    def _resolved_config(self):
+        return normalize_pipeline_config(
+            self.kedro_pipelines[self.name], self.kedro_catalog, self.kedro_parameters
+        )
+
     @strawberry.field
     def describe(self) -> str:
         return self.kedro_pipelines[self.name].describe()
@@ -376,43 +382,26 @@ class PipelineTemplate:
 
     @strawberry.field
     def parameters(self) -> List[Parameter]:
-        # keep track of parameters to avoid returning duplicates
-        params = {}
-        for n in self.kedro_pipelines[self.name].all_inputs():
-            if n.startswith("params:"):
-                name = n.split("params:")[1]
-                value = self.kedro_parameters[name]
-                if not params.get(name, False):
-                    params[name] = value
-            elif n == "parameters":
-                for k, v in self.kedro_parameters.items():
-                    if not params.get(k, False):
-                        params[k] = v
+        _, params, _ = self._resolved_config()
         return [Parameter(name=k, value=v) for k, v in params.items()]
 
     @strawberry.field
     def inputs(self) -> List[DataSet]:
-        inputs_resolved = []
-        for n in self.kedro_pipelines[self.name].all_inputs():
-            if not n.startswith("params:") and n != "parameters":
-                config = self.kedro_catalog[n]
-                inputs_resolved.append(DataSet(name=n, config=json.dumps(config)))
-
-        return inputs_resolved
+        catalog, _, _ = self._resolved_config()
+        return [
+            DataSet(name=name, config=json.dumps(catalog[name]))
+            for name in sorted(self.kedro_pipelines[self.name].all_inputs())
+            if name in catalog
+        ]
 
     @strawberry.field
     def outputs(self) -> List[DataSet]:
-        outputs_resolved = []
-        for n in self.kedro_pipelines[self.name].all_outputs():
-            if self.kedro_catalog.get(n, None):
-                config = self.kedro_catalog[n]
-                outputs_resolved.append(DataSet(name=n, config=json.dumps(config)))
-            else:
-                logger.warning(
-                    f"PipelineTemplate '{self.name}' has an output '{n}' that is not defined in the catalog. This may be due to a missing dataset configuration or because it is a MemoryDataset."
-                )
-
-        return outputs_resolved
+        catalog, _, _ = self._resolved_config()
+        return [
+            DataSet(name=name, config=json.dumps(catalog[name]))
+            for name in sorted(self.kedro_pipelines[self.name].all_outputs())
+            if name in catalog
+        ]
 
 
 @strawberry.type

--- a/src/kedro_graphql/pipeline_config.py
+++ b/src/kedro_graphql/pipeline_config.py
@@ -1,0 +1,137 @@
+"""Pipeline-aware catalog resolution and validation."""
+
+from kedro.io import AbstractDataset, DataCatalog, MemoryDataset
+from kedro.io.core import DatasetError
+
+from .exceptions import InvalidPipeline
+
+
+def normalize_pipeline_config(pipeline, catalog, parameters):
+    """Resolve catalog patterns and retain only config used by ``pipeline``."""
+    dataset_names = sorted(
+        name
+        for name in pipeline.all_inputs() | pipeline.all_outputs()
+        if not name.startswith("params:") and name != "parameters"
+    )
+    candidates = {
+        name: config
+        for name, config in catalog.items()
+        if "{" in name or name in dataset_names
+    }
+    try:
+        resolver = DataCatalog.from_config(catalog=candidates).config_resolver
+        resolved = {
+            name: config
+            for name in dataset_names
+            if (config := resolver.resolve_pattern(name))
+        }
+        # Instantiate the concrete, relevant configurations now so invalid staged
+        # pipelines fail before they are persisted.
+        DataCatalog.from_config(catalog=resolved)
+    except DatasetError as error:
+        raise InvalidPipeline(f"Invalid pipeline catalog: {error}") from error
+
+    parameter_inputs = pipeline.all_inputs()
+    if "parameters" in parameter_inputs:
+        filtered_parameters = parameters
+    else:
+        required = {
+            name.removeprefix("params:")
+            for name in parameter_inputs
+            if name.startswith("params:")
+        }
+        filtered_parameters = {}
+        for name in required:
+            try:
+                filtered_parameters[name] = _parameter_value(parameters, name)
+            except KeyError:
+                pass
+
+    sources = {
+        name: name if name in candidates else resolver.match_pattern(name)
+        for name in resolved
+    }
+    return resolved, filtered_parameters, sources
+
+
+def _parameter_value(parameters, name):
+    if name in parameters:
+        return parameters[name]
+    value = parameters
+    for part in name.split("."):
+        value = value[part]
+    return value
+
+
+def filter_pipeline(pipeline, slices=None):
+    """Apply explicit GraphQL pipeline slices."""
+    filters = {}
+    for item in slices or []:
+        slice_type = item["slice"].lower()
+        filters[slice_type] = (
+            item["args"][0] if slice_type == "node_namespace" else item["args"]
+        )
+    return pipeline.filter(**filters)
+
+
+def filter_only_missing_pipeline(pipeline, catalog):
+    """Build Kedro's dynamic ``only_missing`` execution DAG."""
+    free_outputs = pipeline.outputs() - set(catalog.list())
+    missing = {name for name in catalog.list() if not catalog.exists(name)}
+    to_build = free_outputs | missing
+    filtered = pipeline.only_nodes_with_outputs(*to_build) + pipeline.from_inputs(*to_build)
+
+    unregistered = pipeline.datasets() - set(catalog.list())
+    producers = pipeline.only_nodes_with_outputs(*unregistered)
+    return filtered + producers.to_outputs(*(filtered.inputs() & unregistered))
+
+
+def validate_pipeline_config(
+    pipeline, catalog, parameters, supports_memory_datasets=True
+):
+    """Validate configuration required by the actual execution DAG."""
+    missing_inputs = sorted(
+        name
+        for name in pipeline.inputs()
+        if not name.startswith("params:")
+        and name != "parameters"
+        and name not in catalog
+    )
+    missing_parameters = sorted(
+        name.removeprefix("params:")
+        for name in pipeline.inputs()
+        if name.startswith("params:")
+        and not _has_parameter(parameters, name.removeprefix("params:"))
+    )
+    if missing_inputs or missing_parameters:
+        details = []
+        if missing_inputs:
+            details.append(f"datasets: {', '.join(missing_inputs)}")
+        if missing_parameters:
+            details.append(f"parameters: {', '.join(missing_parameters)}")
+        raise InvalidPipeline("Missing pipeline inputs (" + "; ".join(details) + ").")
+
+    if not supports_memory_datasets:
+        missing_or_memory = []
+        for name in sorted(pipeline.datasets()):
+            if name.startswith("params:") or name == "parameters":
+                continue
+            config = catalog.get(name)
+            if not config or isinstance(
+                AbstractDataset.from_config(name, config), MemoryDataset
+            ):
+                missing_or_memory.append(name)
+        if missing_or_memory:
+            raise InvalidPipeline(
+                "Runner does not support memory datasets; configure persistent datasets for: "
+                + ", ".join(missing_or_memory)
+                + "."
+            )
+
+
+def _has_parameter(parameters, name):
+    try:
+        _parameter_value(parameters, name)
+        return True
+    except (KeyError, TypeError):
+        return False

--- a/src/kedro_graphql/runners/__init__.py
+++ b/src/kedro_graphql/runners/__init__.py
@@ -4,10 +4,13 @@ from importlib import import_module
 logger = logging.getLogger("kedro")
 
 
-def init_runner(runner_import_path: str, **runner_kwargs):
+def get_runner_class(runner_import_path: str):
     module, class_name = runner_import_path.rsplit(".", 1)
-
     module = import_module(module)
-    runner_cls = getattr(module, class_name)
+    return getattr(module, class_name)
+
+
+def init_runner(runner_import_path: str, **runner_kwargs):
+    runner_cls = get_runner_class(runner_import_path)
     logger.info("using runner " + str(runner_cls))
     return runner_cls(**runner_kwargs)

--- a/src/kedro_graphql/runners/argo/argo.py
+++ b/src/kedro_graphql/runners/argo/argo.py
@@ -16,6 +16,8 @@ class ArgoWorkflowsRunner(AbstractRunner):
     """``ArgoWorkflowsRunner`` is an ``AbstractRunner`` implementation. It can be used
     to run pipelines on [argo workflows](https://argoproj.github.io/argo-workflows/).
     """
+    supports_memory_datasets = False
+
     ## NEED TO ADD TO kedro_graphq.config
     namespace = "default"
     host = "http://127.0.0.1:2746"
@@ -148,6 +150,5 @@ class ArgoWorkflowsRunner(AbstractRunner):
         with requests.get(url=endpoint, params=params, stream=True) as resp:
             for _line in resp.iter_lines():
                 self._logger.info(json.loads(_line.decode())["result"]["content"])
-
 
 

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -63,7 +63,7 @@ PERMISSIONS_CLASS = get_permissions(CONFIG.get("KEDRO_GRAPHQL_PERMISSIONS"))
 logger.info("{s} using permissions class: {d}".format(s=__name__, d=PERMISSIONS_CLASS))
 
 
-def _normalize_pipeline(p, app, slices, only_missing, runner):
+def _normalize_pipeline(p, app, slices, only_missing, runner, validate=False):
     full_pipeline = app.kedro_pipelines[p.name]
     submitted_catalog = {
         dataset.name: dataset.parse_config() for dataset in p.data_catalog or []
@@ -86,7 +86,7 @@ def _normalize_pipeline(p, app, slices, only_missing, runner):
         parameter for parameter in p.parameters or [] if parameter.name in parameters
     ]
 
-    if not only_missing:
+    if validate and not only_missing:
         selected_pipeline = filter_pipeline(full_pipeline, slices)
         runner_class = get_runner_class(runner)
         validate_pipeline_config(
@@ -525,6 +525,7 @@ class Mutation:
             d.get("slices"),
             d.get("only_missing", False),
             runner,
+            validate=d["state"] == "READY",
         )
         serial = p.encode(encoder="kedro")
         # credentials not supported yet
@@ -638,6 +639,7 @@ class Mutation:
             pipeline_input_dict.get("slices"),
             pipeline_input_dict.get("only_missing", False),
             runner,
+            validate=requested_state == "READY",
         )
 
         # Update pipeline with normalized pipeline input

--- a/src/kedro_graphql/schema.py
+++ b/src/kedro_graphql/schema.py
@@ -27,7 +27,7 @@ from strawberry.extensions import FieldExtension
 from . import __version__ as kedro_graphql_version
 from .config import load_config
 from .pipeline_event_monitor import PipelineEventMonitor
-from .hooks import InvalidPipeline
+from .exceptions import InvalidPipeline
 from .logs.logger import PipelineLogStream, logger
 from .models import (
     DataSet,
@@ -45,6 +45,12 @@ from .models import (
     SignedUrls,
     State,
 )
+from .pipeline_config import (
+    filter_pipeline,
+    normalize_pipeline_config,
+    validate_pipeline_config,
+)
+from .runners import get_runner_class
 from .tasks import run_pipeline
 from .permissions import get_permissions
 from .signed_url.base import SignedUrlProvider
@@ -55,6 +61,41 @@ logger.debug("configuration loaded by {s}".format(s=__name__))
 
 PERMISSIONS_CLASS = get_permissions(CONFIG.get("KEDRO_GRAPHQL_PERMISSIONS"))
 logger.info("{s} using permissions class: {d}".format(s=__name__, d=PERMISSIONS_CLASS))
+
+
+def _normalize_pipeline(p, app, slices, only_missing, runner):
+    full_pipeline = app.kedro_pipelines[p.name]
+    submitted_catalog = {
+        dataset.name: dataset.parse_config() for dataset in p.data_catalog or []
+    }
+    submitted_parameters = p.serialize()["parameters"]
+    catalog, parameters, sources = normalize_pipeline_config(
+        full_pipeline, submitted_catalog, submitted_parameters
+    )
+
+    datasets = {dataset.name: dataset for dataset in p.data_catalog or []}
+    p.data_catalog = [
+        DataSet(
+            name=name,
+            config=json.dumps(config),
+            tags=datasets[sources[name]].tags if sources[name] in datasets else None,
+        )
+        for name, config in catalog.items()
+    ]
+    p.parameters = [
+        parameter for parameter in p.parameters or [] if parameter.name in parameters
+    ]
+
+    if not only_missing:
+        selected_pipeline = filter_pipeline(full_pipeline, slices)
+        runner_class = get_runner_class(runner)
+        validate_pipeline_config(
+            selected_pipeline,
+            catalog,
+            parameters,
+            getattr(runner_class, "supports_memory_datasets", True),
+        )
+    return p
 
 
 def encode_cursor(id: int) -> str:
@@ -475,10 +516,17 @@ class Mutation:
         p = Pipeline.decode(d)
         p.describe = info.context["request"].app.kedro_pipelines[p.name].describe()
         p.nodes = info.context["request"].app.kedro_pipelines[p.name].nodes
-        serial = p.encode(encoder="kedro")
 
         runner = d.get(
             "runner") or info.context["request"].app.config["KEDRO_GRAPHQL_RUNNER"]
+        p = _normalize_pipeline(
+            p,
+            info.context["request"].app,
+            d.get("slices"),
+            d.get("only_missing", False),
+            runner,
+        )
+        serial = p.encode(encoder="kedro")
         # credentials not supported yet
         # merge any credentials with inputs and outputs
         # credentials are intentionally not persisted
@@ -582,13 +630,21 @@ class Mutation:
                 f"user={PERMISSIONS_CLASS.get_user_info(info)['email']}, action=abort_pipeline, id={p.id}, name={p.name}, task_id={p.status[-1].task_id}")
             return p
 
-        # Update pipeline with new pipeline input
-        p.parameters = pipeline_input_dict.get("parameters")
-        p.data_catalog = pipeline_input_dict.get("data_catalog")
-        p.tags = pipeline_input_dict.get("tags")
-        p.parent = pipeline_input_dict.get("parent")
         runner = pipeline_input_dict.get(
             "runner") or info.context["request"].app.config["KEDRO_GRAPHQL_RUNNER"]
+        submitted = _normalize_pipeline(
+            Pipeline.decode(pipeline_input_dict),
+            info.context["request"].app,
+            pipeline_input_dict.get("slices"),
+            pipeline_input_dict.get("only_missing", False),
+            runner,
+        )
+
+        # Update pipeline with normalized pipeline input
+        p.parameters = submitted.parameters
+        p.data_catalog = submitted.data_catalog
+        p.tags = submitted.tags
+        p.parent = pipeline_input_dict.get("parent")
 
         # If PipelineInput is READY and pipeline is not already running
         if requested_state == "READY" and p.status[-1].state.value not in UNREADY_STATES.union(["READY"]):

--- a/src/kedro_graphql/tasks.py
+++ b/src/kedro_graphql/tasks.py
@@ -22,6 +22,11 @@ from omegaconf import OmegaConf
 from kedro_graphql.logs.logger import KedroGraphQLLogHandler
 from kedro_graphql.utils import add_param_to_feed_dict, run_sync
 from kedro_graphql.runners import init_runner
+from kedro_graphql.pipeline_config import (
+    filter_only_missing_pipeline,
+    filter_pipeline,
+    validate_pipeline_config,
+)
 from kedro_graphql.models import PipelineInput, ParameterInput, Pipeline
 
 # from .config import load_config
@@ -510,13 +515,6 @@ def run_pipeline(self,
                 load_versions=None
             )
 
-            hook_manager.hook.before_pipeline_run(
-                run_params=record_data,
-                pipeline=pipelines.get(name, None),
-                catalog=io
-            )
-
-
             runner_kwargs = conf_parameters.get("runner_kwargs", {})
 
             logger.info(f"Initializing runner {runner} with kwargs: {runner_kwargs}")
@@ -524,32 +522,23 @@ def run_pipeline(self,
 
             # Filter the pipeline based on the slices and only_missing parameters
             if only_missing:
-                # https://github.com/kedro-org/kedro/blob/06d5a6920cbb6b45c07dca6f77d14bb35e283b19/kedro/runner/runner.py#L154
-                free_outputs = pipelines[name].outputs() - set(io.list())
-                missing = {ds for ds in io.list() if not io.exists(ds)}
-                to_build = free_outputs | missing
-                filtered_pipeline = pipelines[name].only_nodes_with_outputs(*to_build) + pipelines[name].from_inputs(
-                    *to_build
+                filtered_pipeline = filter_only_missing_pipeline(pipelines[name], io)
+            else:
+                filtered_pipeline = filter_pipeline(
+                    pipelines[name], slices
                 )
 
-                # We also need any missing datasets that are required to run the
-                # `filtered_pipeline` pipeline, including any chains of missing datasets.
-                unregistered_ds = pipelines[name].datasets() - set(io.list())
-                output_to_unregistered = pipelines[name].only_nodes_with_outputs(
-                    *unregistered_ds)
-                input_from_unregistered = filtered_pipeline.inputs() & unregistered_ds
-                filtered_pipeline += output_to_unregistered.to_outputs(
-                    *input_from_unregistered)
-            else:
-                filtered_pipeline = pipelines[name].filter(
-                    tags=tags,
-                    from_nodes=from_nodes,
-                    to_nodes=to_nodes,
-                    node_names=node_names,
-                    from_inputs=from_inputs,
-                    to_outputs=to_outputs,
-                    node_namespace=node_namespace,
-                )
+            validate_pipeline_config(
+                filtered_pipeline,
+                catalog,
+                parameters,
+                getattr(runner_instance, "supports_memory_datasets", True),
+            )
+            hook_manager.hook.before_pipeline_run(
+                run_params=record_data,
+                pipeline=filtered_pipeline,
+                catalog=io,
+            )
 
             p = run_sync(self.db.read(id=id))
             p.status[-1].filtered_nodes = [node.name for node in filtered_pipeline.nodes]
@@ -695,4 +684,3 @@ def run_pipeline(self,
                 catalog=io
             )
             raise e
-

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -344,7 +344,7 @@ class TestDataSetInput:
 def test_pipeline_input_encodes_nested_dataset_fields_for_graphql():
     result = PipelineInput(
         name="example",
-        data_catalog=[DataSetInput(name="dataset", list_partitions=True)],
+        data_catalog=[{"name": "dataset", "list_partitions": True}],
     ).encode(encoder="graphql")
 
     assert result["dataCatalog"][0]["listPartitions"] is True

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -339,3 +339,13 @@ class TestDataSetInput:
         assert isinstance(result, dict)
         assert result["name"] == dataset.name
         assert result["listPartitions"] is True
+
+
+def test_pipeline_input_encodes_nested_dataset_fields_for_graphql():
+    result = PipelineInput(
+        name="example",
+        data_catalog=[DataSetInput(name="dataset", list_partitions=True)],
+    ).encode(encoder="graphql")
+
+    assert result["dataCatalog"][0]["listPartitions"] is True
+    assert "list_partitions" not in result["dataCatalog"][0]

--- a/src/tests/test_pipeline_config.py
+++ b/src/tests/test_pipeline_config.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import MagicMock
+
+from kedro.pipeline import Pipeline, node
+
+from kedro_graphql.exceptions import InvalidPipeline
+from kedro_graphql.pipeline_config import (
+    filter_only_missing_pipeline,
+    filter_pipeline,
+    normalize_pipeline_config,
+    validate_pipeline_config,
+)
+
+
+def identity(*values):
+    return values[-1]
+
+
+@pytest.fixture
+def factory_pipeline():
+    return Pipeline([
+        node(identity, ["raw", "params:wanted"], "A_output", name="first"),
+        node(identity, "A_output", "B_output", name="second"),
+    ])
+
+
+def test_normalize_pipeline_config_resolves_patterns_and_filters(factory_pipeline):
+    catalog, parameters, sources = normalize_pipeline_config(
+        factory_pipeline,
+        {
+            "raw": {"type": "MemoryDataset"},
+            "{branch}_output": {
+                "type": "pickle.PickleDataset",
+                "filepath": "/tmp/{branch}.pkl",
+            },
+            "unrelated": {"type": "MemoryDataset"},
+        },
+        {"wanted": 1, "unrelated": 2},
+    )
+
+    assert set(catalog) == {"raw", "A_output", "B_output"}
+    assert catalog["A_output"]["filepath"] == "/tmp/A.pkl"
+    assert catalog["B_output"]["filepath"] == "/tmp/B.pkl"
+    assert parameters == {"wanted": 1}
+    assert sources["A_output"] == "{branch}_output"
+
+
+def test_explicit_config_wins_over_pattern(factory_pipeline):
+    catalog, _, sources = normalize_pipeline_config(
+        factory_pipeline,
+        {
+            "raw": {"type": "MemoryDataset"},
+            "A_output": {"type": "MemoryDataset"},
+            "{branch}_output": {
+                "type": "pickle.PickleDataset",
+                "filepath": "/tmp/{branch}.pkl",
+            },
+        },
+        {"wanted": 1},
+    )
+
+    assert catalog["A_output"] == {"type": "MemoryDataset"}
+    assert sources["A_output"] == "A_output"
+
+
+def test_sliced_validation_uses_only_selected_dag(factory_pipeline):
+    selected = filter_pipeline(
+        factory_pipeline, [{"slice": "node_names", "args": ["second"]}]
+    )
+    catalog = {
+        "A_output": {
+            "type": "pickle.PickleDataset",
+            "filepath": "/tmp/A.pkl",
+        }
+    }
+
+    # raw and params:wanted belong to the excluded node and are not required.
+    validate_pipeline_config(selected, catalog, {})
+
+    with pytest.raises(InvalidPipeline, match="A_output"):
+        validate_pipeline_config(selected, {}, {})
+
+
+def test_runner_can_reject_memory_datasets(factory_pipeline):
+    selected = filter_pipeline(
+        factory_pipeline, [{"slice": "node_names", "args": ["second"]}]
+    )
+    persistent = {
+        name: {
+            "type": "pickle.PickleDataset",
+            "filepath": f"/tmp/{name}.pkl",
+        }
+        for name in ("A_output", "B_output")
+    }
+    validate_pipeline_config(selected, persistent, {}, supports_memory_datasets=False)
+
+    with pytest.raises(InvalidPipeline, match="B_output"):
+        validate_pipeline_config(
+            selected,
+            {**persistent, "B_output": {"type": "MemoryDataset"}},
+            {},
+            supports_memory_datasets=False,
+        )
+
+
+def test_only_missing_filter_is_isolated(factory_pipeline):
+    catalog = MagicMock()
+    catalog.list.return_value = ["raw", "A_output", "B_output"]
+    catalog.exists.side_effect = lambda name: name != "B_output"
+
+    filtered = filter_only_missing_pipeline(factory_pipeline, catalog)
+
+    assert [pipeline_node.name for pipeline_node in filtered.nodes] == ["second"]

--- a/src/tests/test_schema_mutation.py
+++ b/src/tests/test_schema_mutation.py
@@ -226,10 +226,9 @@ class TestSchemaMutations:
                                              variable_values={"pipeline": {
                                                  "name": "example00",
                                                  "dataCatalog": [
-                                                     {"name": "text_in", "config": json.dumps({"type": "pandas.CSVDataset", "filepath": str(mock_text_in_tsv), "loadArgs": [
-                                                                                              {"name": "sep", "value": "\t"}], "saveArgs": [{"name": "sep", "value": "\t"}]})},
+                                                     {"name": "text_in", "config": json.dumps({"type": "pandas.CSVDataset", "filepath": str(mock_text_in_tsv), "load_args": {"sep": "\t"}, "save_args": {"sep": "\t"}})},
                                                      {"name": "text_out", "config": json.dumps({"type": "pandas.CSVDataset", "filepath": str(
-                                                         mock_text_out_tsv), "loadArgs": [{"name": "sep", "value": "\t"}], "saveArgs": [{"name": "sep", "value": "\t"}]})}
+                                                         mock_text_out_tsv), "load_args": {"sep": "\t"}, "save_args": {"sep": "\t"}})}
                                                  ],
                                                  "parameters": [{"name": "example", "value": "hello"}],
                                                  "tags": [{"key": "author", "value": "opensean"}, {"key": "package", "value": "kedro-graphql"}]


### PR DESCRIPTION

 ## Summary

  - Resolve Kedro dataset factory patterns before persisting pipeline configuration
  - Validate only the selected execution DAG
  - Allow runners to reject memory datasets
  - Camel-case nested dataset inputs for GraphQL mutations

  ## Testing

  - Added pipeline configuration and nested input serialization tests
  - Direct nested serialization assertion passes
  - Full pytest run unavailable locally because pytest_asyncio is missing from the epi environment